### PR TITLE
PS-2755 - Reset forgot password using OTP [OTP send on mobile and email if exist]

### DIFF
--- a/src/adapters/postgres/user-adapter.ts
+++ b/src/adapters/postgres/user-adapter.ts
@@ -2050,16 +2050,15 @@ export class PostgresUserService implements IServicelocator {
         notificationPayload
       );
       if (mailSend?.result?.email?.errors && mailSend.result.email.errors.length > 0) {
-        // Handle the array of errors
         const errorMessages = mailSend.result.email.errors.map((error: { error: string; }) => error.error);
         const combinedErrorMessage = errorMessages.join(", "); // Combine all error messages into one string
-        // Throw custom error with combined error message
         throw new Error(`error :${combinedErrorMessage}`);
       }
       return mailSend;
     }
     catch (e) {
-      throw e;
+      LoggerUtil.error(API_RESPONSES.EMAIL_ERROR, e.message);
+      throw new Error(`${API_RESPONSES.EMAIL_NOTIFICATION_ERROR}:  ${e.message}`);
     }
   }
 

--- a/src/adapters/userservicelocator.ts
+++ b/src/adapters/userservicelocator.ts
@@ -4,6 +4,7 @@ import { UserCreateDto } from "src/user/dto/user-create.dto";
 import { UserSearchDto } from "src/user/dto/user-search.dto";
 import { OtpVerifyDTO } from "src/user/dto/otpVerify.dto";
 import { UserData } from "src/user/user.controller";
+import { SendPasswordResetOTPDto } from "src/user/dto/passwordReset.dto";
 
 export interface IServicelocator {
   // getUser(
@@ -36,4 +37,5 @@ export interface IServicelocator {
   forgotPassword(request: any, body: any, response: Response);
   sendOtp(body: OtpSendDTO, response: Response): Promise<any>;
   verifyOtp(body: OtpVerifyDTO, response: Response): Promise<any>;
+  sendPasswordResetOTP(body: SendPasswordResetOTPDto, response: Response): Promise<any>;
 }

--- a/src/common/utils/api-id.config.ts
+++ b/src/common/utils/api-id.config.ts
@@ -53,5 +53,6 @@ export const APIID = {
   TENANT_DELETE: "api.tenant.delete",
   TENANT_LIST: "api.tenant.list",
   SEND_OTP: "api.send.OTP",
-  VERIFY_OTP: "api.verify.OTP"
+  VERIFY_OTP: "api.verify.OTP",
+  SEND_RESET_OTP: 'api.send.reset.otp'
 };

--- a/src/common/utils/response.messages.ts
+++ b/src/common/utils/response.messages.ts
@@ -176,5 +176,7 @@ export const API_RESPONSES = {
   MOBILE_OTP_SEND_FAILED: 'Failed to send OTP to mobile',
   EMAIL_SENT_OTP: 'OTP sent successfully to email',
   EMAIL_OTP_SEND_FAILED: 'Failed to send OTP to email',
-  SEND_OTP: 'OTP sent successfully'
+  SEND_OTP: 'OTP sent successfully',
+  EMAIL_NOTIFICATION_ERROR: 'Failed to send Email notification:',
+  EMAIL_ERROR: 'Email notification failed'
 };

--- a/src/common/utils/response.messages.ts
+++ b/src/common/utils/response.messages.ts
@@ -169,5 +169,12 @@ export const API_RESPONSES = {
   USERNAME_REQUIRED: 'Username Required',
   INVALID_REASON: 'Invalid Reason',
   MOBILE_REQUIRED: 'MObile Required',
-  INVALID_HASH_FORMAT: 'Invalid hash format'
+  INVALID_HASH_FORMAT: 'Invalid hash format',
+  NOTIFICATION_ERROR: 'Notification not send due to getting from notification API',
+  MOBILE_EMAIL_NOT_FOUND: 'Mobile number and email ID not found for sending OTP',
+  MOBILE_SENT_OTP: 'OTP sent successfully to mobile',
+  MOBILE_OTP_SEND_FAILED: 'Failed to send OTP to mobile',
+  EMAIL_SENT_OTP: 'OTP sent successfully to email',
+  EMAIL_OTP_SEND_FAILED: 'Failed to send OTP to email',
+  SEND_OTP: 'OTP sent successfully'
 };

--- a/src/user/dto/passwordReset.dto.ts
+++ b/src/user/dto/passwordReset.dto.ts
@@ -31,3 +31,12 @@ export class ForgotPasswordDto {
   @IsNotEmpty()
   token: string;
 }
+
+
+export class SendPasswordResetOTPDto {
+
+  @ApiProperty({ type: () => String, example: 'John' })
+  @IsString()
+  @IsNotEmpty()
+  username: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -46,6 +46,7 @@ import {
   ForgotPasswordDto,
   ResetUserPasswordDto,
   SendPasswordResetLinkDto,
+  SendPasswordResetOTPDto,
 } from "./dto/passwordReset.dto";
 import { isUUID } from "class-validator";
 import { API_RESPONSES } from "@utils/response.messages";
@@ -283,4 +284,16 @@ export class UserController {
   async verifyOtp(@Body() body: OtpVerifyDTO, @Res() response: Response) {
     return this.userAdapter.buildUserAdapter().verifyOtp(body, response);
   }
+  @Post("password-reset-otp")
+  @ApiOkResponse({ description: "Password reset link sent successfully." })
+  @UsePipes(new ValidationPipe({ transform: true }))
+  @ApiBody({ type: SendPasswordResetOTPDto })
+  public async sendPasswordResetOTP(
+    @Req() request: Request,
+    @Res() response: Response,
+    @Body() reqBody: SendPasswordResetOTPDto
+  ) {
+    return await this.userAdapter.buildUserAdapter().sendPasswordResetOTP(reqBody, response)
+  }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to send a password reset OTP via SMS and email.
	- Added a new class for handling password reset OTP requests.
	- Enhanced user feedback with new response messages related to OTP operations.

- **Bug Fixes**
	- Updated existing response messages for consistency.

- **Documentation**
	- Improved API documentation for the new password reset OTP functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->