### PR TITLE
Issue #000000 Change Mobile validation now its 7 to 9 digit

### DIFF
--- a/src/adapters/postgres/user-adapter.ts
+++ b/src/adapters/postgres/user-adapter.ts
@@ -1273,7 +1273,7 @@ export class PostgresUserService implements IServicelocator {
           userCreateDto.mobile
         );
         if (!checkValidMobile) {
-          errorCollector.addError(`Mobile number must be 9 digits long`);
+          errorCollector.addError(`Mobile number must be 7 to 9 digits long`);
         }
       }
 

--- a/src/common/utils/custom-field-validation.ts
+++ b/src/common/utils/custom-field-validation.ts
@@ -10,7 +10,7 @@ export class CustomFieldsValidation {
         break;
 
       case 'mobile':
-        if (fieldValue.length !== 9) {
+        if (fieldValue.length < 7 || fieldValue.length > 9) {
           result = false;
         }
         break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted mobile number validation to accept input lengths between 7 and 9 digits.
  - Updated error messaging to clearly indicate the new acceptable mobile number range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->