### PR TITLE
Update Field Option Read API Increase Default Limit 

### DIFF
--- a/src/adapters/postgres/fields-adapter.ts
+++ b/src/adapters/postgres/fields-adapter.ts
@@ -1194,7 +1194,7 @@ export class PostgresFieldsService implements IServicelocatorfields {
       } = fieldsOptionsSearchDto;
 
       offset = offset || 0;
-      limit = limit || 200;
+      limit = limit || 1000;
 
       const condition: any = {
         name: fieldName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the default number of field options returned per page from 200 to 1000, allowing users to view more options at once when no specific limit is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->