### PR TITLE
Issue #243906 Fix: After manual rejection, rejection email status should be true in database

### DIFF
--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -1113,7 +1113,6 @@ export class PostgresCohortMembersService {
 
       // Store the previous status before updating
       const previousStatus = cohortMembershipToUpdate.status;
-
       
       Object.assign(cohortMembershipToUpdate, cohortMembersUpdateDto);
       const result = await this.cohortMembersRepository.save(

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -1114,6 +1114,7 @@ export class PostgresCohortMembersService {
       // Store the previous status before updating
       const previousStatus = cohortMembershipToUpdate.status;
 
+      
       Object.assign(cohortMembershipToUpdate, cohortMembersUpdateDto);
       const result = await this.cohortMembersRepository.save(
         cohortMembershipToUpdate
@@ -1255,6 +1256,14 @@ export class PostgresCohortMembersService {
               shortlistedStatus: status as 'shortlisted' | 'rejected',
               cohortId: cohortMembershipToUpdate.cohortId,
             });
+
+            // Update rejection_email_sent to true if status is rejected and email was sent successfully
+            if (status === 'rejected') {
+              await this.cohortMembersRepository.update(
+                { cohortMembershipId: cohortMembershipId },
+                { rejectionEmailSent: true }
+              );
+            }
           }
         } else {
           // Log email failure for missing email

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -1113,7 +1113,7 @@ export class PostgresCohortMembersService {
 
       // Store the previous status before updating
       const previousStatus = cohortMembershipToUpdate.status;
-      
+
       Object.assign(cohortMembershipToUpdate, cohortMembersUpdateDto);
       const result = await this.cohortMembersRepository.save(
         cohortMembershipToUpdate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the rejection email status is correctly updated when a cohort member is marked as rejected and the email is sent successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->