### PR TITLE
Removed middleName from bulk import

### DIFF
--- a/src/bulk-import/services/bulk-import.service.ts
+++ b/src/bulk-import/services/bulk-import.service.ts
@@ -798,7 +798,6 @@ export class BulkImportService {
     const coreFieldsToExclude = [
       'firstName',
       'lastName',
-      'middleName',
       'email',
       'gender',
       'dob',
@@ -939,7 +938,6 @@ export class BulkImportService {
     // Step 4: Compose final columns
     const defaultColumns = [
       'firstName',
-      'middleName',
       'lastName',
       'email',
       'gender',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Bulk import now treats Middle Name as an optional, mappable field. It’s no longer included by default in generated templates but can be added via dynamic column selection when needed.
* Improvements
  * Cleaner default import templates with fewer pre-filled columns.
  * Greater flexibility in mapping name fields during CSV/XLSX imports, allowing teams to include Middle Name only when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->