### PR TITLE
Lastname Validation removed now you can pass empty string

### DIFF
--- a/src/adapters/postgres/user-adapter.ts
+++ b/src/adapters/postgres/user-adapter.ts
@@ -1289,13 +1289,26 @@ export class PostgresUserService implements IServicelocator {
       const keycloakReqBody = { username, firstName, lastName, userId, email };
 
       const userData = userDto.userData;
-      const shouldSyncKeycloak =
-        (userData && Object.prototype.hasOwnProperty.call(userData, 'username')) ||
-        (userData && Object.prototype.hasOwnProperty.call(userData, 'firstName')) ||
-        (userData && Object.prototype.hasOwnProperty.call(userData, 'lastName')) ||
-        (userData && Object.prototype.hasOwnProperty.call(userData, 'email'));
 
-      //Update userdetails on keycloak (include when a field is explicitly sent, e.g. lastName: "")
+      // Decide whether to call Keycloak on this update.
+      // - We must not use `if (username || firstName || ...)` alone: empty string is falsy, so e.g. lastName: ""
+      //   would skip Keycloak and leave IdP out of sync with the DB.
+      // - We must not sync on "key exists" only: JSON may send null/undefined; the Keycloak client omits those
+      //   fields, so the request becomes a no-op PUT that can still fail and block the whole update.
+      const keycloakFieldWouldSync = (key: string): boolean => {
+        if (!userData || !Object.prototype.hasOwnProperty.call(userData, key)) {
+          return false;
+        }
+        const v = (userData as Record<string, unknown>)[key];
+        // Include empty string (explicit clear); exclude only missing/nullish values.
+        return v !== undefined && v !== null;
+      };
+      const shouldSyncKeycloak =
+        keycloakFieldWouldSync('username') ||
+        keycloakFieldWouldSync('firstName') ||
+        keycloakFieldWouldSync('lastName') ||
+        keycloakFieldWouldSync('email');
+
       if (shouldSyncKeycloak) {
         try {
           const keycloakUpdateResult = await this.updateUsernameInKeycloak(

--- a/src/adapters/postgres/user-adapter.ts
+++ b/src/adapters/postgres/user-adapter.ts
@@ -1288,8 +1288,15 @@ export class PostgresUserService implements IServicelocator {
       const userId = userDto.userId;
       const keycloakReqBody = { username, firstName, lastName, userId, email };
 
-      //Update userdetails on keycloak
-      if (username || firstName || lastName || email) {
+      const ud = userDto.userData;
+      const shouldSyncKeycloak =
+        (ud && Object.prototype.hasOwnProperty.call(ud, 'username')) ||
+        (ud && Object.prototype.hasOwnProperty.call(ud, 'firstName')) ||
+        (ud && Object.prototype.hasOwnProperty.call(ud, 'lastName')) ||
+        (ud && Object.prototype.hasOwnProperty.call(ud, 'email'));
+
+      //Update userdetails on keycloak (include when a field is explicitly sent, e.g. lastName: "")
+      if (shouldSyncKeycloak) {
         try {
           const keycloakUpdateResult = await this.updateUsernameInKeycloak(
             keycloakReqBody

--- a/src/adapters/postgres/user-adapter.ts
+++ b/src/adapters/postgres/user-adapter.ts
@@ -1288,12 +1288,12 @@ export class PostgresUserService implements IServicelocator {
       const userId = userDto.userId;
       const keycloakReqBody = { username, firstName, lastName, userId, email };
 
-      const ud = userDto.userData;
+      const userData = userDto.userData;
       const shouldSyncKeycloak =
-        (ud && Object.prototype.hasOwnProperty.call(ud, 'username')) ||
-        (ud && Object.prototype.hasOwnProperty.call(ud, 'firstName')) ||
-        (ud && Object.prototype.hasOwnProperty.call(ud, 'lastName')) ||
-        (ud && Object.prototype.hasOwnProperty.call(ud, 'email'));
+        (userData && Object.prototype.hasOwnProperty.call(userData, 'username')) ||
+        (userData && Object.prototype.hasOwnProperty.call(userData, 'firstName')) ||
+        (userData && Object.prototype.hasOwnProperty.call(userData, 'lastName')) ||
+        (userData && Object.prototype.hasOwnProperty.call(userData, 'email'));
 
       //Update userdetails on keycloak (include when a field is explicitly sent, e.g. lastName: "")
       if (shouldSyncKeycloak) {

--- a/src/common/utils/keycloak.adapter.util.ts
+++ b/src/common/utils/keycloak.adapter.util.ts
@@ -283,7 +283,9 @@ async function updateUserInKeyCloak(
   const data = JSON.stringify({
     enabled: true,
     ...(query.firstName && { firstName: query.firstName }),
-    ...(query.lastName != null ? { lastName: query.lastName } : {}),
+    ...(query.lastName === undefined || query.lastName === null
+      ? {}
+      : { lastName: query.lastName }),
     ...(query.username && { username: query.username }),
     ...(query.email && { email: query.email }),
   });

--- a/src/common/utils/keycloak.adapter.util.ts
+++ b/src/common/utils/keycloak.adapter.util.ts
@@ -283,7 +283,7 @@ async function updateUserInKeyCloak(
   const data = JSON.stringify({
     enabled: true,
     ...(query.firstName && { firstName: query.firstName }),
-    ...(query.lastName && { lastName: query.lastName }),
+    ...(query.lastName != null ? { lastName: query.lastName } : {}),
     ...(query.username && { username: query.username }),
     ...(query.email && { email: query.email }),
   });

--- a/src/common/utils/keycloak.adapter.util.ts
+++ b/src/common/utils/keycloak.adapter.util.ts
@@ -266,6 +266,17 @@ interface UpdateUserResponse {
   message: string;
 }
 
+/** Keycloak PATCH: include field when the caller set it (even ""); omit only when undefined/null. */
+function keycloakOptionalString<K extends keyof UpdateUserQuery>(
+  key: K,
+  value: UpdateUserQuery[K],
+): Partial<Pick<UpdateUserQuery, K>> {
+  if (value === undefined || value === null) {
+    return {};
+  }
+  return { [key]: value } as Partial<Pick<UpdateUserQuery, K>>;
+}
+
 async function updateUserInKeyCloak(
   query: UpdateUserQuery,
   token: string
@@ -279,16 +290,29 @@ async function updateUserInKeyCloak(
     };
   }
 
-  // Prepare the payload for the update
-  const data = JSON.stringify({
+  const payload: Record<string, unknown> = {
     enabled: true,
-    ...(query.firstName && { firstName: query.firstName }),
-    ...(query.lastName === undefined || query.lastName === null
-      ? {}
-      : { lastName: query.lastName }),
-    ...(query.username && { username: query.username }),
-    ...(query.email && { email: query.email }),
-  });
+    ...keycloakOptionalString('firstName', query.firstName),
+    ...keycloakOptionalString('lastName', query.lastName),
+    ...keycloakOptionalString('username', query.username),
+    ...keycloakOptionalString('email', query.email),
+  };
+
+  const hasProfileField =
+    Object.prototype.hasOwnProperty.call(payload, 'firstName') ||
+    Object.prototype.hasOwnProperty.call(payload, 'lastName') ||
+    Object.prototype.hasOwnProperty.call(payload, 'username') ||
+    Object.prototype.hasOwnProperty.call(payload, 'email');
+
+  if (!hasProfileField) {
+    return {
+      success: true,
+      statusCode: 204,
+      message: 'No Keycloak profile fields to update; skipped',
+    };
+  }
+
+  const data = JSON.stringify(payload);
 
   // Axios request configuration
   const config: AxiosRequestConfig = {

--- a/src/user/dto/user-update.dto.ts
+++ b/src/user/dto/user-update.dto.ts
@@ -49,13 +49,13 @@ class UserDataDTO {
 
   @ApiProperty({
     type: String,
-    description: 'Last name of the user',
+    description: 'Last name of the user (may be empty)',
     maxLength: 50,
   })
   @Expose()
   @IsOptional()
   @IsString()
-  @Length(1, 50)
+  @Length(0, 50)
   lastName?: string;
 
   @ApiProperty({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile updates now treat explicitly provided empty values (e.g., cleared last name) as intentional and synchronize them to the external identity system; updates are skipped when no profile fields are present.

* **Documentation**
  * API docs and validation updated to state that last name may be empty and to allow zero-length values up to the existing maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->