### PR TITLE
Remove checkoutSessionIdFromPaymentIntent function call from payment success

### DIFF
--- a/src/payments/providers/stripe/stripe.provider.ts
+++ b/src/payments/providers/stripe/stripe.provider.ts
@@ -310,7 +310,6 @@ export class StripeProvider implements PaymentProvider {
       case 'payment_intent.succeeded':
         const paymentIntent = event.data.object as Stripe.PaymentIntent;
         paymentId = paymentIntent.id;
-        sessionId = this.checkoutSessionIdFromPaymentIntent(paymentIntent);
         status = 'success';
         currency = paymentIntent.currency;
         amount = this.convertFromUnitAmount(paymentIntent.amount, currency);


### PR DESCRIPTION
…success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session tracking for Stripe payment confirmation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->