### PR TITLE
Shortlisting email send new API introduce and Remove email notification from the cronjob

### DIFF
--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -670,7 +670,7 @@ export class PostgresCohortMembersService {
     );
 
     if (getUserDetails.length > 0) {
-      results.totalCount = parseInt(getUserDetails[0].total_count, 10);
+      results.totalCount = Number.parseInt(getUserDetails[0].total_count, 10);
       
       if (fieldShowHide === 'false') {
         // No custom fields needed, just push all data
@@ -2941,7 +2941,7 @@ export class PostgresCohortMembersService {
         );
 
         if (optimizedResults.length > 0) {
-          totalCount = parseInt(optimizedResults[0].total_count, 10);
+          totalCount = Number.parseInt(optimizedResults[0].total_count, 10);
 
           // Enrich the results with form data and custom fields
           finalUserDetails = await Promise.all(
@@ -3293,9 +3293,9 @@ export class PostgresCohortMembersService {
     const apiId = APIID.COHORT_MEMBER_EVALUATE_SHORTLISTING;
     // Configurable performance parameters with environment variable fallbacks
     // Use provided batchSize or fall back to environment variable or default
-    const effectiveBatchSize = batchSize || parseInt(process.env.BATCH_SIZE) || 5000;
+    const effectiveBatchSize = batchSize || Number.parseInt(process.env.BATCH_SIZE) || 5000;
     const maxConcurrentBatches =
-      parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
+      Number.parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
     const enableEmailNotifications =
       process.env.ENABLE_SHORTLISTING_EMAILS === 'true';
     const notifyStatuses = ['shortlisted', 'rejected'];
@@ -4059,7 +4059,7 @@ export class PostgresCohortMembersService {
       queryParams.push(batchSize);
     } else if (!userIds || userIds.length === 0) {
       // No batchSize and no userIds filter - use environment variable or default
-      const defaultBatchSize = parseInt(process.env.BATCH_SIZE) || 5000;
+      const defaultBatchSize = Number.parseInt(process.env.BATCH_SIZE) || 5000;
       query += ` LIMIT $${queryParams.length + 1}`;
       queryParams.push(defaultBatchSize);
     }
@@ -4837,9 +4837,7 @@ export class PostgresCohortMembersService {
       const result = await this.sendRejectionEmailNotificationsInternal(
         tenantId,
         academicyearId,
-        userId,
-        undefined,
-        undefined
+        userId
       );
 
       return APIResponse.success(
@@ -4881,9 +4879,9 @@ export class PostgresCohortMembersService {
     // Configurable performance parameters with environment variable fallbacks
     const batchSize =
       batchSizeFromPayload ??
-      (parseInt(process.env.BATCH_SIZE) || 5000);
+      (Number.parseInt(process.env.BATCH_SIZE) || 5000);
     const maxConcurrentBatches =
-      parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
+      Number.parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
     const enableEmailNotifications =
       process.env.ENABLE_SHORTLISTING_EMAILS !== 'false';
 
@@ -5020,9 +5018,9 @@ export class PostgresCohortMembersService {
     const apiId = APIID.COHORT_MEMBER_SEND_SHORTLISTING_EMAILS;
     const batchSize =
       batchSizeFromPayload ??
-      (parseInt(process.env.BATCH_SIZE) || 5000);
+      (Number.parseInt(process.env.BATCH_SIZE) || 5000);
     const maxConcurrentBatches =
-      parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
+      Number.parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
 
     const shortlistNotificationDateFieldId =
       process.env.SHORTLIST_NOTIFICATION_DATE_FIELD_ID;
@@ -5179,8 +5177,7 @@ export class PostgresCohortMembersService {
             maxConcurrentBatches,
             apiId,
             userId,
-            f?.userId,
-            undefined
+            f?.userId
           );
           cohortResults.push(cohortResult);
         }
@@ -5284,7 +5281,7 @@ export class PostgresCohortMembersService {
     fetchLimit?: number
   ) {
     const limit =
-      fetchLimit ?? (parseInt(process.env.BATCH_SIZE) || 5000);
+      fetchLimit ?? (Number.parseInt(process.env.BATCH_SIZE) || 5000);
 
     if (applicantUserId) {
       const query = `
@@ -6664,9 +6661,9 @@ export class PostgresCohortMembersService {
       }
 
       // Validate time components
-      const hourNum = parseInt(hour, 10);
-      const minuteNum = parseInt(minute, 10);
-      const secondNum = parseInt(second, 10);
+      const hourNum = Number.parseInt(hour, 10);
+      const minuteNum = Number.parseInt(minute, 10);
+      const secondNum = Number.parseInt(second, 10);
 
       if (
         hourNum >= 0 &&

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -3335,7 +3335,7 @@ export class PostgresCohortMembersService {
         );
         return [];
       }
-      
+
        ShortlistingLogger.logShortlisting(
         `Found ${activeCohorts.length} active cohorts with shortlist date today or earlier`,
         'ShortlistingEvaluation'
@@ -3892,14 +3892,11 @@ export class PostgresCohortMembersService {
       AND fv."fieldId" = $1
       AND fv."calendarValue"::date <= $2::date
       AND fv."itemId" IS NOT NULL
+      ${cohortFilter}
       ORDER BY c."cohortId"
     `;
 
-    const results = await this.cohortRepository.query(query, [
-      shortlistDateFieldId,
-      currentDateUTC,
-    ]);
-    return results;
+   return this.cohortRepository.query(query, params);
   }
 
   /**

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -3319,12 +3319,13 @@ export class PostgresCohortMembersService {
 
       // Step 1: Process Active Cohorts
       const currentDateUTC = new Date().toISOString(); // Use UTC date for timezone consistency
-      let activeCohorts = await this.processActiveCohorts(
+      const activeCohorts = await this.processActiveCohorts(
         tenantId,
         academicyearId,
         userId,
         shortlistDateFieldId,
-        currentDateUTC
+        currentDateUTC,
+        cohortId
       );
 
       if (activeCohorts.length === 0) {
@@ -3334,43 +3335,6 @@ export class PostgresCohortMembersService {
         );
         return [];
       }
-
-      if (cohortId) {
-        const inWindow = activeCohorts.some(
-          (c: { cohortId: string }) => c.cohortId === cohortId
-        );
-        if (!inWindow) {
-          ShortlistingLogger.logShortlisting(
-            `Requested cohort ${cohortId} is not active or shortlist date is not on/before today`,
-            'ShortlistingEvaluation'
-          );
-          const totalTime = Date.now() - startTime;
-          const performanceMetrics = this.calculatePerformanceMetrics(
-            0,
-            totalTime,
-            effectiveBatchSize,
-            maxConcurrentBatches
-          );
-          return {
-            totalProcessed: 0,
-            totalShortlisted: 0,
-            totalRejected: 0,
-            totalFailures: 0,
-            totalProcessingTime: 0,
-            message:
-              'Target cohort is not in the shortlist date window or is not active',
-            ...performanceMetrics,
-          };
-        }
-        activeCohorts = activeCohorts.filter(
-          (c: { cohortId: string }) => c.cohortId === cohortId
-        );
-      }
-
-      ShortlistingLogger.logShortlisting(
-        `Found ${activeCohorts.length} active cohort(s) with shortlist date today or earlier`,
-        'ShortlistingEvaluation'
-      );
 
       // Step 2: Evaluate Each Cohort
       const cohortResults = [];
@@ -3897,13 +3861,21 @@ export class PostgresCohortMembersService {
    *
    * @param shortlistDateFieldId - The field ID for the shortlist date field
    * @param currentDateUTC - Current UTC date in YYYY-MM-DD format
+   * @param cohortId - When set, only this cohort is queried (must still meet date + active rules)
    * @returns Promise with array of active cohorts for processing
    */
   private async getActiveCohortsWithShortlistDate(
     shortlistDateFieldId: string,
-    currentDateUTC: string
+    currentDateUTC: string,
+    cohortId?: string
   ) {
-    // Optimized query with better indexing and reduced data transfer
+    const params: unknown[] = [shortlistDateFieldId, currentDateUTC];
+    const cohortFilter = cohortId
+      ? ' AND c."cohortId" = $3'
+      : '';
+    if (cohortId) {
+      params.push(cohortId);
+    }
     const query = `
       SELECT DISTINCT 
         c."cohortId", 
@@ -3931,8 +3903,19 @@ export class PostgresCohortMembersService {
    */
   private async getActiveCohortsWithShortlistNotificationDate(
     shortlistNotificationDateFieldId: string,
-    currentDateUTC: string
+    currentDateUTC: string,
+    cohortId?: string
   ) {
+    const params: unknown[] = [
+      shortlistNotificationDateFieldId,
+      currentDateUTC,
+    ];
+    const cohortFilter = cohortId
+      ? ' AND c."cohortId" = $3'
+      : '';
+    if (cohortId) {
+      params.push(cohortId);
+    }
     const query = `
       SELECT DISTINCT 
         c."cohortId", 
@@ -3944,13 +3927,11 @@ export class PostgresCohortMembersService {
       AND fv."fieldId" = $1
       AND fv."calendarValue"::date <= $2::date
       AND fv."itemId" IS NOT NULL
+      ${cohortFilter}
       ORDER BY c."cohortId"
     `;
 
-    return this.cohortRepository.query(query, [
-      shortlistNotificationDateFieldId,
-      currentDateUTC,
-    ]);
+    return this.cohortRepository.query(query, params);
   }
 
   /**
@@ -4551,31 +4532,34 @@ export class PostgresCohortMembersService {
    * @param userId - The user ID from the authenticated request
    * @param shortlistDateFieldId - The field ID for shortlist date
    * @param currentDateUTC - Current UTC date in YYYY-MM-DD format
-   * @returns Promise with active cohorts to process
+   * @param cohortId - When set, the query scopes to this cohort only (active + date window in SQL)
    */
   private async processActiveCohorts(
     tenantId: string,
     academicyearId: string,
     userId: string,
     shortlistDateFieldId: string,
-    currentDateUTC: string
-  ) {
-    // Step 1: Fetch Active Cohorts with Shortlist Date = Today
+    currentDateUTC: string,
+    cohortId?: string
+  ): Promise<any[]> {
     const activeCohorts = await this.getActiveCohortsWithShortlistDate(
       shortlistDateFieldId,
-      currentDateUTC
+      currentDateUTC,
+      cohortId
     );
 
     if (activeCohorts.length === 0) {
       ShortlistingLogger.logShortlisting(
-        'No active cohorts found with shortlist date today or earlier',
+        cohortId
+          ? `No active cohort in shortlist date window for cohortId=${cohortId}`
+          : 'No active cohorts found with shortlist date today or earlier',
         'ShortlistingEvaluation'
       );
       return [];
     }
 
     ShortlistingLogger.logShortlisting(
-      `Found ${activeCohorts.length} active cohorts with shortlist date today or earlier`,
+      `Found ${activeCohorts.length} active cohort(s) with shortlist date today or earlier`,
       'ShortlistingEvaluation'
     );
 
@@ -4905,12 +4889,13 @@ export class PostgresCohortMembersService {
 
       // Step 1: Process Active Cohorts with Rejection Notification Date
       const currentDateUTC = new Date().toISOString().split('T')[0]; // Use UTC date for timezone consistency
-      let activeCohorts = await this.processActiveCohortsForRejectionEmails(
+      const activeCohorts = await this.processActiveCohortsForRejectionEmails(
         tenantId,
         academicyearId,
         userId,
         rejectionNotificationDateFieldId,
-        currentDateUTC
+        currentDateUTC,
+        cohortId
       );
 
       if (activeCohorts.length === 0) {
@@ -4920,43 +4905,10 @@ export class PostgresCohortMembersService {
         );
         return [];
       }
-
-      if (cohortId) {
-        const inWindow = activeCohorts.some(
-          (c: { cohortId: string }) => c.cohortId === cohortId
-        );
-        if (!inWindow) {
-          ShortlistingLogger.logShortlisting(
-            `Requested cohort ${cohortId} is not active or rejection notification date is not on/before today (UTC)`,
-            'RejectionEmailNotification'
-          );
-          const totalTime = Date.now() - startTime;
-          const performanceMetrics = this.calculatePerformanceMetrics(
-            0,
-            totalTime,
-            batchSize,
-            maxConcurrentBatches
-          );
-          return {
-            totalProcessed: 0,
-            totalEmailsSent: 0,
-            totalFailures: 0,
-            totalProcessingTime: 0,
-            message:
-              'Target cohort is not in the rejection-notification-date window or is not active',
-            ...performanceMetrics,
-          };
-        }
-        activeCohorts = activeCohorts.filter(
-          (c: { cohortId: string }) => c.cohortId === cohortId
-        );
-      }
-
       ShortlistingLogger.logShortlisting(
         `Found ${activeCohorts.length} active cohort(s) with rejection notification date today or earlier`,
         'RejectionEmailNotification'
       );
-
       // Step 2: Process Each Cohort for Rejection Emails
       const cohortResults = [];
       for (const cohort of activeCohorts) {
@@ -5045,10 +4997,13 @@ export class PostgresCohortMembersService {
       );
 
       const currentDateUTC = new Date().toISOString().split('T')[0];
+      const cohortIdForQuery =
+        filter?.userId && !filter?.cohortId ? undefined : filter?.cohortId;
       const activeCohorts =
         await this.getActiveCohortsWithShortlistNotificationDate(
           shortlistNotificationDateFieldId,
-          currentDateUTC
+          currentDateUTC,
+          cohortIdForQuery
         );
 
       if (activeCohorts.length === 0) {
@@ -5131,37 +5086,7 @@ export class PostgresCohortMembersService {
           cohortResults.push(cohortResult);
         }
       } else {
-        let cohortsToProcess = activeCohorts;
-        if (f?.cohortId) {
-          const inWindow = activeCohorts.some(
-            (c: { cohortId: string }) => c.cohortId === f.cohortId
-          );
-          if (!inWindow) {
-            ShortlistingLogger.logShortlisting(
-              `Target cohort ${f.cohortId} is not active or shortlist notification date is not on/before today (UTC)`,
-              'ShortlistingEmailNotification'
-            );
-            const totalTime = Date.now() - startTime;
-            const performanceMetrics = this.calculatePerformanceMetrics(
-              0,
-              totalTime,
-              batchSize,
-              maxConcurrentBatches
-            );
-            return {
-              totalProcessed: 0,
-              totalEmailsSent: 0,
-              totalFailures: 0,
-              totalProcessingTime: 0,
-              message:
-                'Target cohort is not in the shortlist-notification-date window or is not active',
-              ...performanceMetrics,
-            };
-          }
-          cohortsToProcess = activeCohorts.filter(
-            (c: { cohortId: string }) => c.cohortId === f.cohortId
-          );
-        }
+        const cohortsToProcess = activeCohorts;
 
         ShortlistingLogger.logShortlisting(
           `Found ${cohortsToProcess.length} cohort(s) to process for shortlisting emails`,
@@ -5595,32 +5520,35 @@ export class PostgresCohortMembersService {
    * @param userId - The user ID from the authenticated request
    * @param rejectionNotificationDateFieldId - The field ID for rejection notification date
    * @param currentDateUTC - Current UTC date in YYYY-MM-DD format
-   * @returns Promise with active cohorts to process
+   * @param cohortId - When set, the query scopes to this cohort only (active + date window in SQL)
    */
   private async processActiveCohortsForRejectionEmails(
     tenantId: string,
     academicyearId: string,
     userId: string,
     rejectionNotificationDateFieldId: string,
-    currentDateUTC: string
-  ) {
-    // Step 1: Fetch Active Cohorts with Rejection Notification Date = Today or Earlier
+    currentDateUTC: string,
+    cohortId?: string
+  ): Promise<any[]> {
     const activeCohorts =
       await this.getActiveCohortsWithRejectionNotificationDate(
         rejectionNotificationDateFieldId,
-        currentDateUTC
+        currentDateUTC,
+        cohortId
       );
 
     if (activeCohorts.length === 0) {
       ShortlistingLogger.logShortlisting(
-        'No active cohorts found with rejection notification date today or earlier',
+        cohortId
+          ? `No active cohort in rejection-notification date window for cohortId=${cohortId}`
+          : 'No active cohorts found with rejection notification date today or earlier',
         'RejectionEmailNotification'
       );
       return [];
     }
 
     ShortlistingLogger.logShortlisting(
-      `Found ${activeCohorts.length} active cohorts with rejection notification date today or earlier`,
+      `Found ${activeCohorts.length} active cohort(s) with rejection notification date today or earlier`,
       'RejectionEmailNotification'
     );
 
@@ -5636,13 +5564,24 @@ export class PostgresCohortMembersService {
    *
    * @param rejectionNotificationDateFieldId - The field ID for the rejection notification date field
    * @param currentDateUTC - Current UTC date in YYYY-MM-DD format
+   * @param cohortId - When set, only this cohort is queried (must still meet date + active rules)
    * @returns Promise with array of active cohorts for processing
    */
   private async getActiveCohortsWithRejectionNotificationDate(
     rejectionNotificationDateFieldId: string,
-    currentDateUTC: string
+    currentDateUTC: string,
+    cohortId?: string
   ) {
-    // Optimized query with better indexing and reduced data transfer
+    const params: unknown[] = [
+      rejectionNotificationDateFieldId,
+      currentDateUTC,
+    ];
+    const cohortFilter = cohortId
+      ? ' AND c."cohortId" = $3'
+      : '';
+    if (cohortId) {
+      params.push(cohortId);
+    }
     const query = `
       SELECT DISTINCT 
         c."cohortId", 
@@ -5654,15 +5593,11 @@ export class PostgresCohortMembersService {
       AND fv."fieldId" = $1
       AND fv."calendarValue"::date <= $2::date
       AND fv."itemId" IS NOT NULL
+      ${cohortFilter}
       ORDER BY c."cohortId"
     `;
 
-    const results = await this.cohortRepository.query(query, [
-      rejectionNotificationDateFieldId,
-      currentDateUTC,
-    ]);
-
-    return results;
+    return this.cohortRepository.query(query, params);
   }
 
   /**

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -3523,12 +3523,27 @@ export class PostgresCohortMembersService {
     let failures = 0;
 
     const batchStartTime = Date.now();
+    const userIds = members.map((m) => m.userId);
+
+    const autoTagsByUserId = new Map<string, string[]>();
+    if (userIds.length > 0) {
+      const usersForTags = await this.usersRepository.find({
+        where: { userId: In(userIds) },
+        select: ['userId', 'auto_tags'],
+      });
+      for (const u of usersForTags) {
+        autoTagsByUserId.set(
+          u.userId,
+          Array.isArray((u as any).auto_tags) ? (u as any).auto_tags : []
+        );
+      }
+    }
+
     // Pre-fetch all user field values for this batch to reduce database calls
     // This optimization significantly improves performance for large batches
     // Skip field value fetching if no rules exist (automatic shortlisting)
     let userFieldValuesMap = new Map();
     if (formFieldsAndRules && formFieldsAndRules.length > 0) {
-      const userIds = members.map((m) => m.userId);
       userFieldValuesMap = await this.getBatchUserFieldValues(userIds);
     }
 
@@ -3537,12 +3552,14 @@ export class PostgresCohortMembersService {
       try {
         // Get pre-fetched field values for this user (empty array if no rules exist)
         const userFieldValues = userFieldValuesMap.get(member.userId) || [];
+        const userAutoTags = autoTagsByUserId.get(member.userId) ?? [];
 
         // Step 6: Evaluate rules and determine status
         const evaluationResult = await this.evaluateMemberRules(
           member,
           userFieldValues,
-          formFieldsAndRules
+          formFieldsAndRules,
+          userAutoTags
         );
 
         // Step 7: Update member status using the optimized batch update method
@@ -3675,6 +3692,9 @@ export class PostgresCohortMembersService {
         }
       }
 
+      // Shortlisted emails are sent via POST cohortmember/cron/send-shortlisting-emails
+      // (updates rejection_email_sent when status is shortlisted). Inline send disabled:
+      /*
       // NEW REQUIREMENT: Only send email notifications for 'shortlisted' status
       const enableEmailNotifications =
         process.env.ENABLE_SHORTLISTING_EMAILS !== 'false';
@@ -3765,6 +3785,7 @@ export class PostgresCohortMembersService {
           });
         }
       }
+      */
     } catch (error) {
       // Log the error and re-throw for batch processing error handling
       ShortlistingLogger.logShortlistingError(
@@ -3868,6 +3889,34 @@ export class PostgresCohortMembersService {
       currentDateUTC,
     ]);
     return results;
+  }
+
+  /**
+   * Active cohorts whose shortlist *notification* date (custom FieldValues on cohort) is ≤ today UTC.
+   * Used by send-shortlisting-emails cron; mirrors getActiveCohortsWithRejectionNotificationDate.
+   */
+  private async getActiveCohortsWithShortlistNotificationDate(
+    shortlistNotificationDateFieldId: string,
+    currentDateUTC: string
+  ) {
+    const query = `
+      SELECT DISTINCT 
+        c."cohortId", 
+        c."name", 
+        c."status"
+      FROM public."Cohort" c
+      INNER JOIN public."FieldValues" fv ON c."cohortId" = fv."itemId"
+      WHERE c."status" = 'active'
+      AND fv."fieldId" = $1
+      AND fv."calendarValue"::date <= $2::date
+      AND fv."itemId" IS NOT NULL
+      ORDER BY c."cohortId"
+    `;
+
+    return this.cohortRepository.query(query, [
+      shortlistNotificationDateFieldId,
+      currentDateUTC,
+    ]);
   }
 
   /**
@@ -4107,13 +4156,25 @@ export class PostgresCohortMembersService {
    * @param member - The cohort member to evaluate
    * @param userFieldValues - Array of field values for the member
    * @param formFieldsAndRules - Array of form fields and rules
+   * @param userAutoTags - User.auto_tags from Users table (batch-loaded); completed_alumni forces reject
    * @returns Promise with evaluation result (status and statusReason)
    */
   private async evaluateMemberRules(
     member: any,
     userFieldValues: any[],
-    formFieldsAndRules: any[]
+    formFieldsAndRules: any[],
+    userAutoTags?: string[] | null
   ) {
+    if (this.userHasCompletedAlumniAutoTag(userAutoTags)) {
+      return {
+        status: 'rejected',
+        statusReason:
+          'User has completed_alumni auto tag and is not eligible for shortlisting',
+        userId: member.userId,
+        cohortId: member.cohortId,
+      };
+    }
+
     // If no forms or rules are defined for this cohort, skip processing
     if (!formFieldsAndRules || formFieldsAndRules.length === 0) {
       return {
@@ -4162,6 +4223,14 @@ export class PostgresCohortMembersService {
       userId: member.userId,
       cohortId: member.cohortId,
     };
+  }
+
+  /** Users with completed_alumni in auto_tags are rejected before form rules run */
+  private userHasCompletedAlumniAutoTag(autoTags?: string[] | null): boolean {
+    if (!autoTags || !Array.isArray(autoTags)) {
+      return false;
+    }
+    return autoTags.includes('completed_alumni');
   }
 
   /**
@@ -4862,6 +4931,479 @@ export class PostgresCohortMembersService {
       );
 
       throw error;
+    }
+  }
+
+  /**
+   * Sends onStudentShortlisted emails for shortlisted members with rejection_email_sent false.
+   * Cohort selection uses SHORTLIST_NOTIFICATION_DATE_FIELD_ID (calendar on cohort FieldValues ≤ today UTC),
+   * same pattern as rejection emails’ notification date field.
+   */
+  public async sendShortlistingEmailNotificationsInternal(
+    tenantId: string,
+    academicyearId: string,
+    userId: string,
+    filter?: { cohortId: string; userId: string }
+  ) {
+    const apiId = APIID.COHORT_MEMBER_SEND_SHORTLISTING_EMAILS;
+    const batchSize = parseInt(process.env.BATCH_SIZE) || 5000;
+    const maxConcurrentBatches =
+      parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
+
+    const shortlistNotificationDateFieldId =
+      process.env.SHORTLIST_NOTIFICATION_DATE_FIELD_ID;
+
+    if (!shortlistNotificationDateFieldId) {
+      throw new Error(
+        'SHORTLIST_NOTIFICATION_DATE_FIELD_ID environment variable is required for shortlisting email notifications'
+      );
+    }
+
+    const startTime = Date.now();
+
+    try {
+      ShortlistingLogger.logShortlisting(
+        `Starting shortlisting email notifications with batch size: ${batchSize}, max concurrent batches: ${maxConcurrentBatches}` +
+          (filter
+            ? ` (targeted cohortId=${filter.cohortId} applicantUserId=${filter.userId})`
+            : ''),
+        'ShortlistingEmailNotification'
+      );
+
+      const currentDateUTC = new Date().toISOString().split('T')[0];
+      const activeCohorts =
+        await this.getActiveCohortsWithShortlistNotificationDate(
+          shortlistNotificationDateFieldId,
+          currentDateUTC
+        );
+
+      if (activeCohorts.length === 0) {
+        ShortlistingLogger.logShortlisting(
+          'No active cohorts found with shortlist notification date today or earlier',
+          'ShortlistingEmailNotification'
+        );
+        const totalTime = Date.now() - startTime;
+        const performanceMetrics = this.calculatePerformanceMetrics(
+          0,
+          totalTime,
+          batchSize,
+          maxConcurrentBatches
+        );
+        return {
+          totalProcessed: 0,
+          totalEmailsSent: 0,
+          totalFailures: 0,
+          totalProcessingTime: 0,
+          message: 'No cohorts to process',
+          ...performanceMetrics,
+        };
+      }
+
+      let cohortsToProcess = activeCohorts;
+      if (filter) {
+        const inWindow = activeCohorts.some(
+          (c: { cohortId: string }) => c.cohortId === filter.cohortId
+        );
+        if (!inWindow) {
+          ShortlistingLogger.logShortlisting(
+            `Target cohort ${filter.cohortId} is not active or shortlist notification date is not on/before today (UTC)`,
+            'ShortlistingEmailNotification'
+          );
+          const totalTime = Date.now() - startTime;
+          const performanceMetrics = this.calculatePerformanceMetrics(
+            0,
+            totalTime,
+            batchSize,
+            maxConcurrentBatches
+          );
+          return {
+            totalProcessed: 0,
+            totalEmailsSent: 0,
+            totalFailures: 0,
+            totalProcessingTime: 0,
+            message:
+              'Target cohort is not in the shortlist-notification-date window or is not active',
+            ...performanceMetrics,
+          };
+        }
+        cohortsToProcess = activeCohorts.filter(
+          (c: { cohortId: string }) => c.cohortId === filter.cohortId
+        );
+      }
+
+      ShortlistingLogger.logShortlisting(
+        `Found ${cohortsToProcess.length} cohort(s) to process for shortlisting emails`,
+        'ShortlistingEmailNotification'
+      );
+
+      const cohortResults = [];
+      for (const cohort of cohortsToProcess) {
+        const cohortResult = await this.processCohortForShortlistingEmails(
+          cohort,
+          tenantId,
+          batchSize,
+          maxConcurrentBatches,
+          apiId,
+          userId,
+          filter?.userId
+        );
+        cohortResults.push(cohortResult);
+      }
+
+      const aggregatedResults =
+        this.aggregateRejectionEmailResults(cohortResults);
+
+      const totalTime = Date.now() - startTime;
+      const performanceMetrics = this.calculatePerformanceMetrics(
+        aggregatedResults.totalProcessed,
+        totalTime,
+        batchSize,
+        maxConcurrentBatches
+      );
+
+      return {
+        ...aggregatedResults,
+        ...performanceMetrics,
+        message: 'Shortlisting email notifications completed successfully',
+      };
+    } catch (error) {
+      const totalTime = Date.now() - startTime;
+
+      ShortlistingLogger.logShortlistingError(
+        `Error in shortlisting email notifications after ${totalTime}ms`,
+        error.message,
+        'ShortlistingEmailNotification'
+      );
+
+      throw error;
+    }
+  }
+
+  private async processCohortForShortlistingEmails(
+    cohort: any,
+    tenantId: string,
+    batchSize: number,
+    maxConcurrentBatches: number,
+    apiId: string,
+    userId: string,
+    applicantUserId?: string
+  ) {
+    const processingStartTime = Date.now();
+    const cohortId = cohort.cohortId;
+
+    try {
+      const members = await this.getShortlistedMembersForEmailNotification(
+        cohortId,
+        applicantUserId
+      );
+
+      if (members.length === 0) {
+        return {
+          processed: 0,
+          emailsSent: 0,
+          failures: 0,
+          processingTime: Date.now() - processingStartTime,
+        };
+      }
+
+      const result = await this.processShortlistingEmailBatchesInParallel(
+        members,
+        cohortId,
+        batchSize,
+        maxConcurrentBatches,
+        apiId,
+        userId
+      );
+
+      const processingTime = Date.now() - processingStartTime;
+
+      return {
+        ...result,
+        processingTime,
+      };
+    } catch (error) {
+      ShortlistingLogger.logShortlistingError(
+        `Failed to process shortlisting emails for cohort ${cohortId}`,
+        error.message,
+        'ShortlistingEmailNotification'
+      );
+
+      return {
+        processed: 0,
+        emailsSent: 0,
+        failures: 0,
+        processingTime: Date.now() - processingStartTime,
+      };
+    }
+  }
+
+  private async getShortlistedMembersForEmailNotification(
+    cohortId: string,
+    applicantUserId?: string
+  ) {
+    const batchSize = parseInt(process.env.BATCH_SIZE) || 5000;
+
+    if (applicantUserId) {
+      const query = `
+      SELECT 
+        cm."cohortMembershipId",
+        cm."cohortId",
+        cm."userId",
+        cm."status",
+        cm."statusReason",
+        cm."rejection_email_sent",
+        cm."createdAt",
+        cm."updatedAt"
+      FROM public."CohortMembers" cm
+      WHERE cm."cohortId" = $1 
+      AND cm."userId" = $2
+      AND cm."status" = 'shortlisted'
+      AND (cm."rejection_email_sent" IS NULL OR cm."rejection_email_sent" = false)
+      ORDER BY cm."createdAt" ASC
+      LIMIT 1
+    `;
+      return this.cohortMembersRepository.query(query, [
+        cohortId,
+        applicantUserId,
+      ]);
+    }
+
+    const query = `
+      SELECT 
+        cm."cohortMembershipId",
+        cm."cohortId",
+        cm."userId",
+        cm."status",
+        cm."statusReason",
+        cm."rejection_email_sent",
+        cm."createdAt",
+        cm."updatedAt"
+      FROM public."CohortMembers" cm
+      WHERE cm."cohortId" = $1 
+      AND cm."status" = 'shortlisted'
+      AND (cm."rejection_email_sent" IS NULL OR cm."rejection_email_sent" = false)
+      ORDER BY cm."createdAt" ASC
+      LIMIT $2
+    `;
+
+    const members = await this.cohortMembersRepository.query(query, [
+      cohortId,
+      batchSize,
+    ]);
+
+    return members;
+  }
+
+  private async processShortlistingEmailBatchesInParallel(
+    members: any[],
+    cohortId: string,
+    batchSize: number,
+    maxConcurrentBatches: number,
+    apiId: string,
+    userId: string
+  ) {
+    let totalProcessed = 0;
+    let totalEmailsSent = 0;
+    let totalFailures = 0;
+
+    const batches = [];
+    for (let i = 0; i < members.length; i += batchSize) {
+      batches.push(members.slice(i, i + batchSize));
+    }
+
+    ShortlistingLogger.logShortlisting(
+      `Processing ${batches.length} batches for shortlisting emails in cohort ${cohortId} with max ${maxConcurrentBatches} concurrent batches`,
+      'ShortlistingEmailNotification'
+    );
+
+    for (let i = 0; i < batches.length; i += maxConcurrentBatches) {
+      const currentBatches = batches.slice(i, i + maxConcurrentBatches);
+
+      const batchPromises = currentBatches.map((batch, batchIndex) =>
+        this.processShortlistingEmailBatch(
+          batch,
+          cohortId,
+          apiId,
+          i + batchIndex + 1,
+          batches.length,
+          userId
+        )
+      );
+
+      const batchResults = await Promise.all(batchPromises);
+
+      batchResults.forEach((result) => {
+        totalProcessed += result.processed;
+        totalEmailsSent += result.emailsSent;
+        totalFailures += result.failures;
+      });
+
+      if ((i / maxConcurrentBatches + 1) % 10 === 0) {
+        ShortlistingLogger.logShortlisting(
+          `Cohort ${cohortId} shortlisting emails: Completed ${Math.min(
+            i + maxConcurrentBatches,
+            batches.length
+          )}/${batches.length} batch groups`,
+          'ShortlistingEmailNotification'
+        );
+      }
+    }
+
+    return {
+      processed: totalProcessed,
+      emailsSent: totalEmailsSent,
+      failures: totalFailures,
+    };
+  }
+
+  private async processShortlistingEmailBatch(
+    members: any[],
+    cohortId: string,
+    apiId: string,
+    batchNumber: number,
+    totalBatches: number,
+    userId: string
+  ) {
+    let processed = 0;
+    let emailsSent = 0;
+    let failures = 0;
+
+    const batchStartTime = Date.now();
+
+    const userIds = members.map((m) => m.userId);
+    const userDataMap = new Map();
+
+    if (userIds.length > 0) {
+      const users = await this.usersRepository.find({
+        where: { userId: In(userIds) },
+        select: ['userId', 'email', 'firstName', 'lastName'],
+      });
+
+      users.forEach((user) => {
+        userDataMap.set(user.userId, user);
+      });
+    }
+
+    for (const member of members) {
+      try {
+        const userData = userDataMap.get(member.userId);
+
+        if (!userData?.email) {
+          ShortlistingLogger.logEmailFailure({
+            dateTime: new Date().toISOString(),
+            userId: member.userId,
+            email: 'No email found',
+            shortlistedStatus: 'shortlisted',
+            failureReason: `No email found for user ${member.userId}`,
+            cohortId: member.cohortId,
+          });
+          failures++;
+          processed++;
+          continue;
+        }
+
+        await this.sendShortlistingEmailNotification(
+          member,
+          userData,
+          cohortId,
+          userId
+        );
+
+        await this.cohortMembersRepository.update(
+          { cohortMembershipId: member.cohortMembershipId },
+          { rejectionEmailSent: true }
+        );
+
+        processed++;
+        emailsSent++;
+      } catch (error) {
+        failures++;
+        processed++;
+
+        ShortlistingLogger.logShortlistingError(
+          `Failed to process shortlisting email for member ${member.userId} in batch ${batchNumber}/${totalBatches}`,
+          error.message,
+          'ShortlistingEmailNotification'
+        );
+
+        ShortlistingLogger.logEmailFailure({
+          dateTime: new Date().toISOString(),
+          userId: member.userId,
+          email: 'Unknown',
+          shortlistedStatus: 'shortlisted',
+          failureReason: error.message,
+          cohortId: member.cohortId,
+        });
+      }
+    }
+
+    const batchTime = Date.now() - batchStartTime;
+
+    if (batchTime > 5000) {
+      ShortlistingLogger.logShortlisting(
+        `Slow shortlisting email batch detected: Batch ${batchNumber}/${totalBatches} took ${batchTime}ms for ${processed} records`,
+        'ShortlistingEmailNotification',
+        undefined,
+        'warn'
+      );
+    }
+
+    return { processed, emailsSent, failures };
+  }
+
+  private async sendShortlistingEmailNotification(
+    member: any,
+    userData: any,
+    cohortId: string,
+    _userId: string
+  ) {
+    const cohortData = await this.cohortRepository.findOne({
+      where: { cohortId: cohortId },
+    });
+
+    const notificationPayload = {
+      isQueue: false,
+      context: 'USER',
+      key: 'onStudentShortlisted',
+      replacements: {
+        '{username}': `${userData.firstName ?? ''} ${
+          userData.lastName ?? ''
+        }`.trim(),
+        '{firstName}': userData.firstName ?? '',
+        '{lastName}': userData.lastName ?? '',
+        '{programName}': cohortData?.name ?? 'the program',
+        '{status}': 'shortlisted',
+        '{statusReason}': member.statusReason ?? 'Not specified',
+      },
+      email: {
+        receipients: [userData.email],
+      },
+    };
+
+    const mailSend = await this.notificationRequest.sendNotification(
+      notificationPayload
+    );
+
+    if (mailSend?.result?.email?.errors?.length > 0) {
+      ShortlistingLogger.logEmailFailure({
+        dateTime: new Date().toISOString(),
+        userId: userData.userId,
+        email: userData.email,
+        shortlistedStatus: 'shortlisted',
+        failureReason: mailSend.result.email.errors.join(', '),
+        cohortId: cohortId,
+      });
+      throw new Error(
+        `Email sending failed: ${mailSend.result.email.errors.join(', ')}`
+      );
+    } else {
+      ShortlistingLogger.logEmailSuccess({
+        dateTime: new Date().toISOString(),
+        userId: userData.userId,
+        email: userData.email,
+        shortlistedStatus: 'shortlisted',
+        cohortId: cohortId,
+      });
     }
   }
 

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -5126,8 +5126,7 @@ export class PostgresCohortMembersService {
             maxConcurrentBatches,
             apiId,
             userId,
-            undefined,
-            cohortMembers
+            { preloadedMembers: cohortMembers }
           );
           cohortResults.push(cohortResult);
         }
@@ -5177,7 +5176,7 @@ export class PostgresCohortMembersService {
             maxConcurrentBatches,
             apiId,
             userId,
-            f?.userId
+            f?.userId ? { applicantUserId: f.userId } : undefined
           );
           cohortResults.push(cohortResult);
         }
@@ -5219,21 +5218,24 @@ export class PostgresCohortMembersService {
     maxConcurrentBatches: number,
     apiId: string,
     userId: string,
-    applicantUserId?: string,
-    preloadedMembers?: any[]
+    options?: {
+      applicantUserId?: string;
+      preloadedMembers?: any[];
+    }
   ) {
     const processingStartTime = Date.now();
     const cohortId = cohort.cohortId;
+    const applicantUserId = options?.applicantUserId;
+    const preloadedMembers = options?.preloadedMembers;
 
     try {
       const members =
-        preloadedMembers !== undefined
-          ? preloadedMembers
-          : await this.getShortlistedMembersForEmailNotification(
-              cohortId,
-              applicantUserId,
-              batchSize
-            );
+        preloadedMembers ??
+        (await this.getShortlistedMembersForEmailNotification(
+          cohortId,
+          applicantUserId,
+          batchSize
+        ));
 
       if (members.length === 0) {
         return {

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -3279,6 +3279,7 @@ export class PostgresCohortMembersService {
    * @param userId - The user ID from the authenticated request
    * @param batchSize - Optional batch size for processing (overrides environment variable)
    * @param userIds - Optional array of user IDs to filter processing (only these users will be processed)
+   * @param cohortId - Optional cohort UUID; when set, only that cohort is evaluated (must be in shortlist window)
    * @returns Promise with evaluation results and performance metrics
    */
   public async evaluateCohortMemberShortlistingStatusInternal(
@@ -3286,7 +3287,8 @@ export class PostgresCohortMembersService {
     academicyearId: string,
     userId: string,
     batchSize?: number,
-    userIds?: string[]
+    userIds?: string[],
+    cohortId?: string
   ) {
     const apiId = APIID.COHORT_MEMBER_EVALUATE_SHORTLISTING;
     // Configurable performance parameters with environment variable fallbacks
@@ -3311,13 +3313,13 @@ export class PostgresCohortMembersService {
 
     try {
       ShortlistingLogger.logShortlisting(
-        `Starting cohort member shortlisting evaluation with batch size: ${effectiveBatchSize}, max concurrent batches: ${maxConcurrentBatches}, userIds filter: ${userIds ? userIds.length + ' users' : 'all users'}`,
+        `Starting cohort member shortlisting evaluation with batch size: ${effectiveBatchSize}, max concurrent batches: ${maxConcurrentBatches}, userIds filter: ${userIds ? userIds.length + ' users' : 'all users'}, cohortId: ${cohortId ?? 'all'}`,
         'ShortlistingEvaluation'
       );
 
       // Step 1: Process Active Cohorts
       const currentDateUTC = new Date().toISOString(); // Use UTC date for timezone consistency
-      const activeCohorts = await this.processActiveCohorts(
+      let activeCohorts = await this.processActiveCohorts(
         tenantId,
         academicyearId,
         userId,
@@ -3333,8 +3335,40 @@ export class PostgresCohortMembersService {
         return [];
       }
 
+      if (cohortId) {
+        const inWindow = activeCohorts.some(
+          (c: { cohortId: string }) => c.cohortId === cohortId
+        );
+        if (!inWindow) {
+          ShortlistingLogger.logShortlisting(
+            `Requested cohort ${cohortId} is not active or shortlist date is not on/before today`,
+            'ShortlistingEvaluation'
+          );
+          const totalTime = Date.now() - startTime;
+          const performanceMetrics = this.calculatePerformanceMetrics(
+            0,
+            totalTime,
+            effectiveBatchSize,
+            maxConcurrentBatches
+          );
+          return {
+            totalProcessed: 0,
+            totalShortlisted: 0,
+            totalRejected: 0,
+            totalFailures: 0,
+            totalProcessingTime: 0,
+            message:
+              'Target cohort is not in the shortlist date window or is not active',
+            ...performanceMetrics,
+          };
+        }
+        activeCohorts = activeCohorts.filter(
+          (c: { cohortId: string }) => c.cohortId === cohortId
+        );
+      }
+
       ShortlistingLogger.logShortlisting(
-        `Found ${activeCohorts.length} active cohorts with shortlist date today or earlier`,
+        `Found ${activeCohorts.length} active cohort(s) with shortlist date today or earlier`,
         'ShortlistingEvaluation'
       );
 
@@ -4803,7 +4837,9 @@ export class PostgresCohortMembersService {
       const result = await this.sendRejectionEmailNotificationsInternal(
         tenantId,
         academicyearId,
-        userId
+        userId,
+        undefined,
+        undefined
       );
 
       return APIResponse.success(
@@ -4837,11 +4873,15 @@ export class PostgresCohortMembersService {
   public async sendRejectionEmailNotificationsInternal(
     tenantId: string,
     academicyearId: string,
-    userId: string
+    userId: string,
+    cohortId?: string,
+    batchSizeFromPayload?: number
   ) {
     const apiId = APIID.COHORT_MEMBER_SEND_REJECTION_EMAILS;
     // Configurable performance parameters with environment variable fallbacks
-    const batchSize = parseInt(process.env.BATCH_SIZE) || 5000;
+    const batchSize =
+      batchSizeFromPayload ??
+      (parseInt(process.env.BATCH_SIZE) || 5000);
     const maxConcurrentBatches =
       parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
     const enableEmailNotifications =
@@ -4861,13 +4901,13 @@ export class PostgresCohortMembersService {
 
     try {
       ShortlistingLogger.logShortlisting(
-        `Starting rejection email notifications with batch size: ${batchSize}, max concurrent batches: ${maxConcurrentBatches}`,
+        `Starting rejection email notifications with batch size: ${batchSize}, max concurrent batches: ${maxConcurrentBatches}, cohortId: ${cohortId ?? 'all'}`,
         'RejectionEmailNotification'
       );
 
       // Step 1: Process Active Cohorts with Rejection Notification Date
       const currentDateUTC = new Date().toISOString().split('T')[0]; // Use UTC date for timezone consistency
-      const activeCohorts = await this.processActiveCohortsForRejectionEmails(
+      let activeCohorts = await this.processActiveCohortsForRejectionEmails(
         tenantId,
         academicyearId,
         userId,
@@ -4883,8 +4923,39 @@ export class PostgresCohortMembersService {
         return [];
       }
 
+      if (cohortId) {
+        const inWindow = activeCohorts.some(
+          (c: { cohortId: string }) => c.cohortId === cohortId
+        );
+        if (!inWindow) {
+          ShortlistingLogger.logShortlisting(
+            `Requested cohort ${cohortId} is not active or rejection notification date is not on/before today (UTC)`,
+            'RejectionEmailNotification'
+          );
+          const totalTime = Date.now() - startTime;
+          const performanceMetrics = this.calculatePerformanceMetrics(
+            0,
+            totalTime,
+            batchSize,
+            maxConcurrentBatches
+          );
+          return {
+            totalProcessed: 0,
+            totalEmailsSent: 0,
+            totalFailures: 0,
+            totalProcessingTime: 0,
+            message:
+              'Target cohort is not in the rejection-notification-date window or is not active',
+            ...performanceMetrics,
+          };
+        }
+        activeCohorts = activeCohorts.filter(
+          (c: { cohortId: string }) => c.cohortId === cohortId
+        );
+      }
+
       ShortlistingLogger.logShortlisting(
-        `Found ${activeCohorts.length} active cohorts with rejection notification date today or earlier`,
+        `Found ${activeCohorts.length} active cohort(s) with rejection notification date today or earlier`,
         'RejectionEmailNotification'
       );
 
@@ -4943,10 +5014,13 @@ export class PostgresCohortMembersService {
     tenantId: string,
     academicyearId: string,
     userId: string,
-    filter?: { cohortId: string; userId: string }
+    filter?: { cohortId?: string; userId?: string },
+    batchSizeFromPayload?: number
   ) {
     const apiId = APIID.COHORT_MEMBER_SEND_SHORTLISTING_EMAILS;
-    const batchSize = parseInt(process.env.BATCH_SIZE) || 5000;
+    const batchSize =
+      batchSizeFromPayload ??
+      (parseInt(process.env.BATCH_SIZE) || 5000);
     const maxConcurrentBatches =
       parseInt(process.env.MAX_CONCURRENT_BATCHES) || 10;
 
@@ -4965,7 +5039,9 @@ export class PostgresCohortMembersService {
       ShortlistingLogger.logShortlisting(
         `Starting shortlisting email notifications with batch size: ${batchSize}, max concurrent batches: ${maxConcurrentBatches}` +
           (filter
-            ? ` (targeted cohortId=${filter.cohortId} applicantUserId=${filter.userId})`
+            ? ` (filter cohortId=${filter.cohortId ?? '—'} applicantUserId=${
+                filter.userId ?? '—'
+              })`
             : ''),
         'ShortlistingEmailNotification'
       );
@@ -4999,16 +5075,25 @@ export class PostgresCohortMembersService {
         };
       }
 
-      let cohortsToProcess = activeCohorts;
-      if (filter) {
-        const inWindow = activeCohorts.some(
-          (c: { cohortId: string }) => c.cohortId === filter.cohortId
+      const f = filter;
+      const cohortResults: {
+        processed: number;
+        emailsSent: number;
+        failures: number;
+        processingTime: number;
+      }[] = [];
+
+      // Applicant only: shortlisted rows for this user across all notification-window cohorts
+      if (f?.userId && !f.cohortId) {
+        const activeIds = activeCohorts.map(
+          (c: { cohortId: string }) => c.cohortId
         );
-        if (!inWindow) {
-          ShortlistingLogger.logShortlisting(
-            `Target cohort ${filter.cohortId} is not active or shortlist notification date is not on/before today (UTC)`,
-            'ShortlistingEmailNotification'
+        const members =
+          await this.getShortlistedMembersForApplicantInActiveCohorts(
+            f.userId,
+            activeIds
           );
+        if (members.length === 0) {
           const totalTime = Date.now() - startTime;
           const performanceMetrics = this.calculatePerformanceMetrics(
             0,
@@ -5022,32 +5107,83 @@ export class PostgresCohortMembersService {
             totalFailures: 0,
             totalProcessingTime: 0,
             message:
-              'Target cohort is not in the shortlist-notification-date window or is not active',
+              'No eligible shortlisted memberships for applicant in notification-window cohorts',
             ...performanceMetrics,
           };
         }
-        cohortsToProcess = activeCohorts.filter(
-          (c: { cohortId: string }) => c.cohortId === filter.cohortId
-        );
-      }
+        const byCohort = new Map<string, any[]>();
+        for (const m of members) {
+          const cid = m.cohortId;
+          if (!byCohort.has(cid)) {
+            byCohort.set(cid, []);
+          }
+          byCohort.get(cid).push(m);
+        }
+        for (const [, cohortMembers] of byCohort) {
+          const cohortId = cohortMembers[0].cohortId;
+          const cohortResult = await this.processCohortForShortlistingEmails(
+            { cohortId },
+            tenantId,
+            batchSize,
+            maxConcurrentBatches,
+            apiId,
+            userId,
+            undefined,
+            cohortMembers
+          );
+          cohortResults.push(cohortResult);
+        }
+      } else {
+        let cohortsToProcess = activeCohorts;
+        if (f?.cohortId) {
+          const inWindow = activeCohorts.some(
+            (c: { cohortId: string }) => c.cohortId === f.cohortId
+          );
+          if (!inWindow) {
+            ShortlistingLogger.logShortlisting(
+              `Target cohort ${f.cohortId} is not active or shortlist notification date is not on/before today (UTC)`,
+              'ShortlistingEmailNotification'
+            );
+            const totalTime = Date.now() - startTime;
+            const performanceMetrics = this.calculatePerformanceMetrics(
+              0,
+              totalTime,
+              batchSize,
+              maxConcurrentBatches
+            );
+            return {
+              totalProcessed: 0,
+              totalEmailsSent: 0,
+              totalFailures: 0,
+              totalProcessingTime: 0,
+              message:
+                'Target cohort is not in the shortlist-notification-date window or is not active',
+              ...performanceMetrics,
+            };
+          }
+          cohortsToProcess = activeCohorts.filter(
+            (c: { cohortId: string }) => c.cohortId === f.cohortId
+          );
+        }
 
-      ShortlistingLogger.logShortlisting(
-        `Found ${cohortsToProcess.length} cohort(s) to process for shortlisting emails`,
-        'ShortlistingEmailNotification'
-      );
-
-      const cohortResults = [];
-      for (const cohort of cohortsToProcess) {
-        const cohortResult = await this.processCohortForShortlistingEmails(
-          cohort,
-          tenantId,
-          batchSize,
-          maxConcurrentBatches,
-          apiId,
-          userId,
-          filter?.userId
+        ShortlistingLogger.logShortlisting(
+          `Found ${cohortsToProcess.length} cohort(s) to process for shortlisting emails`,
+          'ShortlistingEmailNotification'
         );
-        cohortResults.push(cohortResult);
+
+        for (const cohort of cohortsToProcess) {
+          const cohortResult = await this.processCohortForShortlistingEmails(
+            cohort,
+            tenantId,
+            batchSize,
+            maxConcurrentBatches,
+            apiId,
+            userId,
+            f?.userId,
+            undefined
+          );
+          cohortResults.push(cohortResult);
+        }
       }
 
       const aggregatedResults =
@@ -5086,16 +5222,21 @@ export class PostgresCohortMembersService {
     maxConcurrentBatches: number,
     apiId: string,
     userId: string,
-    applicantUserId?: string
+    applicantUserId?: string,
+    preloadedMembers?: any[]
   ) {
     const processingStartTime = Date.now();
     const cohortId = cohort.cohortId;
 
     try {
-      const members = await this.getShortlistedMembersForEmailNotification(
-        cohortId,
-        applicantUserId
-      );
+      const members =
+        preloadedMembers !== undefined
+          ? preloadedMembers
+          : await this.getShortlistedMembersForEmailNotification(
+              cohortId,
+              applicantUserId,
+              batchSize
+            );
 
       if (members.length === 0) {
         return {
@@ -5139,9 +5280,11 @@ export class PostgresCohortMembersService {
 
   private async getShortlistedMembersForEmailNotification(
     cohortId: string,
-    applicantUserId?: string
+    applicantUserId?: string,
+    fetchLimit?: number
   ) {
-    const batchSize = parseInt(process.env.BATCH_SIZE) || 5000;
+    const limit =
+      fetchLimit ?? (parseInt(process.env.BATCH_SIZE) || 5000);
 
     if (applicantUserId) {
       const query = `
@@ -5188,10 +5331,44 @@ export class PostgresCohortMembersService {
 
     const members = await this.cohortMembersRepository.query(query, [
       cohortId,
-      batchSize,
+      limit,
     ]);
 
     return members;
+  }
+
+  /**
+   * Shortlisted members for one applicant across cohorts that are in the notification window.
+   */
+  private async getShortlistedMembersForApplicantInActiveCohorts(
+    applicantUserId: string,
+    cohortIds: string[]
+  ) {
+    if (!cohortIds.length) {
+      return [];
+    }
+    const query = `
+      SELECT 
+        cm."cohortMembershipId",
+        cm."cohortId",
+        cm."userId",
+        cm."status",
+        cm."statusReason",
+        cm."rejection_email_sent",
+        cm."createdAt",
+        cm."updatedAt"
+      FROM public."CohortMembers" cm
+      WHERE cm."userId" = $1
+      AND cm."cohortId" = ANY($2::uuid[])
+      AND cm."status" = 'shortlisted'
+      AND (cm."rejection_email_sent" IS NULL OR cm."rejection_email_sent" = false)
+      ORDER BY cm."cohortId", cm."createdAt" ASC
+    `;
+
+    return this.cohortMembersRepository.query(query, [
+      applicantUserId,
+      cohortIds,
+    ]);
   }
 
   private async processShortlistingEmailBatchesInParallel(
@@ -5515,7 +5692,8 @@ export class PostgresCohortMembersService {
     try {
       // Get rejected members that need email notifications
       const members = await this.getRejectedMembersForEmailNotification(
-        cohortId
+        cohortId,
+        batchSize
       );
 
       if (members.length === 0) {
@@ -5566,7 +5744,10 @@ export class PostgresCohortMembersService {
    * @param cohortId - The cohort ID to fetch members for
    * @returns Promise with array of rejected cohort members
    */
-  private async getRejectedMembersForEmailNotification(cohortId: string) {
+  private async getRejectedMembersForEmailNotification(
+    cohortId: string,
+    fetchLimit: number
+  ) {
     // Optimized query with proper indexing and LIMIT for batch processing
     const query = `
       SELECT 
@@ -5586,10 +5767,9 @@ export class PostgresCohortMembersService {
       LIMIT $2
     `;
 
-    const batchSize = parseInt(process.env.BATCH_SIZE) || 5000;
     const members = await this.cohortMembersRepository.query(query, [
       cohortId,
-      batchSize,
+      fetchLimit,
     ]);
 
     return members;

--- a/src/adapters/postgres/cohortMembers-adapter.ts
+++ b/src/adapters/postgres/cohortMembers-adapter.ts
@@ -3335,6 +3335,11 @@ export class PostgresCohortMembersService {
         );
         return [];
       }
+      
+       ShortlistingLogger.logShortlisting(
+        `Found ${activeCohorts.length} active cohorts with shortlist date today or earlier`,
+        'ShortlistingEvaluation'
+      );
 
       // Step 2: Evaluate Each Cohort
       const cohortResults = [];

--- a/src/cohortMembers/cohortMembers-cron.service.ts
+++ b/src/cohortMembers/cohortMembers-cron.service.ts
@@ -133,6 +133,7 @@ export class CohortMembersCronService {
    * @param userId - The user ID from the authenticated request
    * @param batchSize - Optional batch size for processing (overrides environment variable)
    * @param userIds - Optional array of user IDs to filter processing (only these users will be processed)
+   * @param cohortId - Optional cohort UUID to scope evaluation to one cohort
    * @returns Promise with evaluation results
    */
   async triggerShortlistingEvaluation(
@@ -140,10 +141,11 @@ export class CohortMembersCronService {
     academicYearId: string,
     userId: string,
     batchSize?: number,
-    userIds?: string[]
+    userIds?: string[],
+    cohortId?: string
   ): Promise<any> {
     this.logger.log(
-      `Manual trigger of shortlisting evaluation for tenant: ${tenantId}, academic year: ${academicYearId}, user: ${userId}, batchSize: ${batchSize || 'default'}, userIds filter: ${userIds ? userIds.length + ' users' : 'all users'}`
+      `Manual trigger of shortlisting evaluation for tenant: ${tenantId}, academic year: ${academicYearId}, user: ${userId}, batchSize: ${batchSize || 'default'}, userIds filter: ${userIds ? userIds.length + ' users' : 'all users'}, cohortId: ${cohortId ?? 'all'}`
     );
 
     try {
@@ -154,7 +156,8 @@ export class CohortMembersCronService {
           academicYearId,
           userId,
           batchSize,
-          userIds
+          userIds,
+          cohortId
         );
 
       this.logger.log(`Manual shortlisting evaluation completed successfully`);
@@ -182,10 +185,12 @@ export class CohortMembersCronService {
   async triggerRejectionEmailNotification(
     tenantId: string,
     academicYearId: string,
-    userId: string
+    userId: string,
+    cohortId?: string,
+    batchSize?: number
   ): Promise<any> {
     this.logger.log(
-      `Manual trigger of rejection email notification for tenant: ${tenantId}, academic year: ${academicYearId}, user: ${userId}`
+      `Manual trigger of rejection email notification for tenant: ${tenantId}, academic year: ${academicYearId}, user: ${userId}, cohortId: ${cohortId ?? 'all'}, batchSize: ${batchSize ?? 'default'}`
     );
 
     try {
@@ -194,7 +199,9 @@ export class CohortMembersCronService {
         await this.cohortMembersService.sendRejectionEmailNotificationsInternal(
           tenantId,
           academicYearId,
-          userId
+          userId,
+          cohortId,
+          batchSize
         );
 
       this.logger.log(`Manual rejection email notification completed successfully`);
@@ -219,13 +226,17 @@ export class CohortMembersCronService {
     tenantId: string,
     academicYearId: string,
     userId: string,
-    filter?: { cohortId: string; userId: string }
+    filter?: { cohortId?: string; userId?: string },
+    batchSize?: number
   ): Promise<any> {
     this.logger.log(
       `Manual trigger of shortlisting email notification for tenant: ${tenantId}, academic year: ${academicYearId}, user: ${userId}` +
         (filter
-          ? `, filter cohortId=${filter.cohortId} applicantUserId=${filter.userId}`
-          : '')
+          ? `, filter cohortId=${filter.cohortId ?? '—'} applicantUserId=${
+              filter.userId ?? '—'
+            }`
+          : '') +
+        `, batchSize: ${batchSize ?? 'env'}`
     );
 
     try {
@@ -234,7 +245,8 @@ export class CohortMembersCronService {
           tenantId,
           academicYearId,
           userId,
-          filter
+          filter,
+          batchSize
         );
 
       this.logger.log(

--- a/src/cohortMembers/cohortMembers-cron.service.ts
+++ b/src/cohortMembers/cohortMembers-cron.service.ts
@@ -209,4 +209,45 @@ export class CohortMembersCronService {
       throw error;
     }
   }
+
+  /**
+   * Manual trigger for shortlisted-user email notifications (onStudentShortlisted).
+   * Same operational pattern as rejection emails: separate cron endpoint updates
+   * CohortMembers.rejection_email_sent after a successful send (shortlisted rows only).
+   */
+  async triggerShortlistingEmailNotification(
+    tenantId: string,
+    academicYearId: string,
+    userId: string,
+    filter?: { cohortId: string; userId: string }
+  ): Promise<any> {
+    this.logger.log(
+      `Manual trigger of shortlisting email notification for tenant: ${tenantId}, academic year: ${academicYearId}, user: ${userId}` +
+        (filter
+          ? `, filter cohortId=${filter.cohortId} applicantUserId=${filter.userId}`
+          : '')
+    );
+
+    try {
+      const result =
+        await this.cohortMembersService.sendShortlistingEmailNotificationsInternal(
+          tenantId,
+          academicYearId,
+          userId,
+          filter
+        );
+
+      this.logger.log(
+        `Manual shortlisting email notification completed successfully`
+      );
+      return result;
+    } catch (error) {
+      this.logger.error(
+        `Manual shortlisting email notification failed: ${error.message}`,
+        error.stack
+      );
+
+      throw error;
+    }
+  }
 }

--- a/src/cohortMembers/cohortMembers.controller.ts
+++ b/src/cohortMembers/cohortMembers.controller.ts
@@ -42,6 +42,7 @@ import APIResponse from 'src/common/responses/response';
 import { ShortlistingLogger } from 'src/common/logger/ShortlistingLogger';
 import { CohortMembersCronService } from './cohortMembers-cron.service';
 import { EvaluateShortlistingDto } from './dto/evaluate-shortlisting.dto';
+import { SendShortlistingEmailsDto } from './dto/send-shortlisting-emails.dto';
 
 // Extend Express Request type to include user
 interface RequestWithUser extends Request {
@@ -605,6 +606,138 @@ export class CohortMembersController {
       );
 
       // Return error response
+      return APIResponse.error(
+        res,
+        apiId,
+        `Error: ${error.message}`,
+        API_RESPONSES.INTERNAL_SERVER_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+  /**
+   * Cron-style endpoint: send shortlisted-user emails (onStudentShortlisted) and set
+   * rejection_email_sent on success (same column as rejection cron; only shortlisted rows are selected).
+   *
+   * Optional body: both `cohortId` and `userId` (applicant) to send at most one email for that member;
+   * cohort must still be in the shortlist-notification-date window (SHORTLIST_NOTIFICATION_DATE_FIELD_ID).
+   * Omit both for default multi-cohort behavior.
+   */
+  @Post('cron/send-shortlisting-emails')
+  @ApiBody({ type: SendShortlistingEmailsDto, required: false })
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      skipMissingProperties: true,
+      whitelist: true,
+    })
+  )
+  async sendShortlistingEmails(
+    @Req() req: RequestWithUser,
+    @Res() res: Response,
+    @Body() body?: SendShortlistingEmailsDto,
+    @Query('userid') queryUserId?: string
+  ) {
+    const apiId = APIID.COHORT_MEMBER_SEND_SHORTLISTING_EMAILS;
+
+    try {
+      const tenantId = req.headers['tenantid'] as string;
+      const academicyearId = req.headers['academicyearid'] as string;
+      const headerUserId = req.headers['userid'] as string;
+      const userId = headerUserId || queryUserId;
+
+      const filterCohortId = body?.cohortId;
+      const filterApplicantUserId = body?.userId;
+      if (filterCohortId || filterApplicantUserId) {
+        if (!filterCohortId || !filterApplicantUserId) {
+          return APIResponse.error(
+            res,
+            apiId,
+            API_RESPONSES.BAD_REQUEST,
+            'cohortId and userId must both be provided in the body for a targeted send, or omit both for default processing.',
+            HttpStatus.BAD_REQUEST
+          );
+        }
+      }
+
+      if (!userId) {
+        return APIResponse.error(
+          res,
+          apiId,
+          API_RESPONSES.BAD_REQUEST,
+          'User ID not found in request. Please ensure you are authenticated.',
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
+      if (!tenantId) {
+        return APIResponse.error(
+          res,
+          apiId,
+          API_RESPONSES.BAD_REQUEST,
+          API_RESPONSES.TANANT_ID_REQUIRED,
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
+      if (!academicyearId) {
+        return APIResponse.error(
+          res,
+          apiId,
+          'Academic year ID is required in headers',
+          API_RESPONSES.BAD_REQUEST,
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
+      if (!isUUID(tenantId)) {
+        return APIResponse.error(
+          res,
+          apiId,
+          'Invalid tenant ID format. Must be a valid UUID.',
+          API_RESPONSES.BAD_REQUEST,
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
+      if (!isUUID(academicyearId)) {
+        return APIResponse.error(
+          res,
+          apiId,
+          'Invalid academic year ID format. Must be a valid UUID.',
+          API_RESPONSES.BAD_REQUEST,
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
+      const result =
+        await this.cohortMembersCronService.triggerShortlistingEmailNotification(
+          tenantId,
+          academicyearId,
+          userId,
+          filterCohortId && filterApplicantUserId
+            ? {
+                cohortId: filterCohortId,
+                userId: filterApplicantUserId,
+              }
+            : undefined
+        );
+
+      return APIResponse.success(
+        res,
+        apiId,
+        result,
+        HttpStatus.OK,
+        'Shortlisting email notifications completed successfully'
+      );
+    } catch (error) {
+      ShortlistingLogger.logShortlistingError(
+        'Error in manual shortlisting email notification endpoint',
+        `Error: ${error.message}`,
+        apiId
+      );
+
       return APIResponse.error(
         res,
         apiId,

--- a/src/cohortMembers/cohortMembers.controller.ts
+++ b/src/cohortMembers/cohortMembers.controller.ts
@@ -457,8 +457,8 @@ export class CohortMembersController {
         return APIResponse.error(
           res,
           apiId,
-          API_RESPONSES.BAD_REQUEST,
           'Invalid cohortId format. Must be a valid UUID.',
+          API_RESPONSES.BAD_REQUEST,
           HttpStatus.BAD_REQUEST
         );
       }

--- a/src/cohortMembers/cohortMembers.controller.ts
+++ b/src/cohortMembers/cohortMembers.controller.ts
@@ -43,6 +43,7 @@ import { ShortlistingLogger } from 'src/common/logger/ShortlistingLogger';
 import { CohortMembersCronService } from './cohortMembers-cron.service';
 import { EvaluateShortlistingDto } from './dto/evaluate-shortlisting.dto';
 import { SendShortlistingEmailsDto } from './dto/send-shortlisting-emails.dto';
+import { SendRejectionEmailsDto } from './dto/send-rejection-emails.dto';
 
 // Extend Express Request type to include user
 interface RequestWithUser extends Request {
@@ -376,7 +377,7 @@ export class CohortMembersController {
    *
    * @param req - Express request object containing headers
    * @param res - Express response object
-   * @param body - Request body containing optional batchSize and userId array
+   * @param body - Request body containing optional batchSize, userId array, and cohortId
    * @param queryUserId - Optional userId from query parameter (for backward compatibility)
    * @returns JSON response with processing results and performance metrics
    */
@@ -452,6 +453,16 @@ export class CohortMembersController {
         );
       }
 
+      if (body?.cohortId && !isUUID(body.cohortId)) {
+        return APIResponse.error(
+          res,
+          apiId,
+          API_RESPONSES.BAD_REQUEST,
+          'Invalid cohortId format. Must be a valid UUID.',
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
       // Trigger the shortlisting evaluation process with user ID, batchSize, and userId array
       // If body is not provided or empty, use undefined to maintain backward compatibility
       const result =
@@ -460,7 +471,8 @@ export class CohortMembersController {
           academicyearId,
           userId,
           body?.batchSize,
-          body?.userId
+          body?.userId,
+          body?.cohortId
         );
 
       // Return success response with the result data
@@ -510,12 +522,22 @@ export class CohortMembersController {
    *
    * @param req - Express request object containing headers
    * @param res - Express response object
+   * @param body - Optional cohortId (scope to one cohort in window) and batchSize
    * @returns JSON response with processing results and performance metrics
    */
   @Post('cron/send-rejection-emails')
+  @ApiBody({ type: SendRejectionEmailsDto, required: false })
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      skipMissingProperties: true,
+      whitelist: true,
+    })
+  )
   async sendRejectionEmails(
     @Req() req: RequestWithUser,
     @Res() res: Response,
+    @Body() body?: SendRejectionEmailsDto,
     @Query('userid') queryUserId?: string
   ) {
     const apiId = APIID.COHORT_MEMBER_SEND_REJECTION_EMAILS;
@@ -581,12 +603,24 @@ export class CohortMembersController {
         );
       }
 
+      if (body?.cohortId && !isUUID(body.cohortId)) {
+        return APIResponse.error(
+          res,
+          apiId,
+          API_RESPONSES.BAD_REQUEST,
+          'Invalid cohortId format. Must be a valid UUID.',
+          HttpStatus.BAD_REQUEST
+        );
+      }
+
       // Trigger the rejection email notification process with user ID
       const result =
         await this.cohortMembersCronService.triggerRejectionEmailNotification(
           tenantId,
           academicyearId,
-          userId
+          userId,
+          body?.cohortId,
+          body?.batchSize
         );
 
       // Return success response with the result data
@@ -620,9 +654,8 @@ export class CohortMembersController {
    * Cron-style endpoint: send shortlisted-user emails (onStudentShortlisted) and set
    * rejection_email_sent on success (same column as rejection cron; only shortlisted rows are selected).
    *
-   * Optional body: both `cohortId` and `userId` (applicant) to send at most one email for that member;
-   * cohort must still be in the shortlist-notification-date window (SHORTLIST_NOTIFICATION_DATE_FIELD_ID).
-   * Omit both for default multi-cohort behavior.
+   * Optional JSON body: `cohortId` / `userId` filters; optional `batchSize` (else BATCH_SIZE env).
+   * Cohorts must be in the shortlist-notification-date window (SHORTLIST_NOTIFICATION_DATE_FIELD_ID).
    */
   @Post('cron/send-shortlisting-emails')
   @ApiBody({ type: SendShortlistingEmailsDto, required: false })
@@ -649,16 +682,23 @@ export class CohortMembersController {
 
       const filterCohortId = body?.cohortId;
       const filterApplicantUserId = body?.userId;
-      if (filterCohortId || filterApplicantUserId) {
-        if (!filterCohortId || !filterApplicantUserId) {
-          return APIResponse.error(
-            res,
-            apiId,
-            API_RESPONSES.BAD_REQUEST,
-            'cohortId and userId must both be provided in the body for a targeted send, or omit both for default processing.',
-            HttpStatus.BAD_REQUEST
-          );
-        }
+      if (filterCohortId && !isUUID(filterCohortId)) {
+        return APIResponse.error(
+          res,
+          apiId,
+          API_RESPONSES.BAD_REQUEST,
+          'Invalid cohortId format. Must be a valid UUID.',
+          HttpStatus.BAD_REQUEST
+        );
+      }
+      if (filterApplicantUserId && !isUUID(filterApplicantUserId)) {
+        return APIResponse.error(
+          res,
+          apiId,
+          API_RESPONSES.BAD_REQUEST,
+          'Invalid userId format. Must be a valid UUID.',
+          HttpStatus.BAD_REQUEST
+        );
       }
 
       if (!userId) {
@@ -711,17 +751,23 @@ export class CohortMembersController {
         );
       }
 
+      const filterPayload =
+        filterCohortId || filterApplicantUserId
+          ? {
+              ...(filterCohortId ? { cohortId: filterCohortId } : {}),
+              ...(filterApplicantUserId
+                ? { userId: filterApplicantUserId }
+                : {}),
+            }
+          : undefined;
+
       const result =
         await this.cohortMembersCronService.triggerShortlistingEmailNotification(
           tenantId,
           academicyearId,
           userId,
-          filterCohortId && filterApplicantUserId
-            ? {
-                cohortId: filterCohortId,
-                userId: filterApplicantUserId,
-              }
-            : undefined
+          filterPayload,
+          body?.batchSize
         );
 
       return APIResponse.success(

--- a/src/cohortMembers/dto/evaluate-shortlisting.dto.ts
+++ b/src/cohortMembers/dto/evaluate-shortlisting.dto.ts
@@ -37,6 +37,16 @@ export class EvaluateShortlistingDto {
   @IsUUID('4', { each: true, message: 'Each userId must be a valid UUID' })
   userId?: string[];
 
+  @ApiProperty({
+    type: String,
+    description:
+      'Optional cohort UUID. When set, evaluation runs only for this cohort (must be in shortlist-date window).',
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID('4', { message: 'cohortId must be a valid UUID' })
+  cohortId?: string;
+
   constructor(obj: any) {
     Object.assign(this, obj);
   }

--- a/src/cohortMembers/dto/send-rejection-emails.dto.ts
+++ b/src/cohortMembers/dto/send-rejection-emails.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsUUID,
+  IsInt,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * Optional body for POST cohortmember/cron/send-rejection-emails.
+ */
+export class SendRejectionEmailsDto {
+  @ApiProperty({
+    required: false,
+    description:
+      'When set, only this cohort is processed (must be in rejection-notification-date window).',
+  })
+  @IsOptional()
+  @IsUUID('4', { message: 'cohortId must be a valid UUID' })
+  cohortId?: string;
+
+  @ApiProperty({
+    type: Number,
+    description: 'Optional batch size override (defaults to BATCH_SIZE env)',
+    required: false,
+  })
+  @IsOptional()
+  @ValidateIf((o) => o.batchSize !== undefined && o.batchSize !== null)
+  @Type(() => Number)
+  @IsInt({ message: 'batchSize must be an integer' })
+  @Min(1, { message: 'batchSize must be at least 1' })
+  batchSize?: number;
+}

--- a/src/cohortMembers/dto/send-shortlisting-emails.dto.ts
+++ b/src/cohortMembers/dto/send-shortlisting-emails.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+
+/**
+ * Optional body for POST cohortmember/cron/send-shortlisting-emails.
+ * When both cohortId and userId are set, only that cohort member may receive mail
+ * (cohort in shortlist *notification* date window, shortlisted, email not yet sent).
+ * Omit both for default batch behavior across all eligible cohorts.
+ */
+export class SendShortlistingEmailsDto {
+  @ApiProperty({
+    required: false,
+    description:
+      'Cohort UUID; must be sent together with userId for targeted send',
+  })
+  @IsOptional()
+  @IsUUID('4', { message: 'cohortId must be a valid UUID' })
+  cohortId?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Applicant user UUID; must be sent together with cohortId for targeted send',
+  })
+  @IsOptional()
+  @IsUUID('4', { message: 'userId must be a valid UUID' })
+  userId?: string;
+}

--- a/src/cohortMembers/dto/send-shortlisting-emails.dto.ts
+++ b/src/cohortMembers/dto/send-shortlisting-emails.dto.ts
@@ -1,17 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsUUID } from 'class-validator';
+import {
+  IsOptional,
+  IsUUID,
+  IsInt,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 
 /**
  * Optional body for POST cohortmember/cron/send-shortlisting-emails.
- * When both cohortId and userId are set, only that cohort member may receive mail
- * (cohort in shortlist *notification* date window, shortlisted, email not yet sent).
- * Omit both for default batch behavior across all eligible cohorts.
+ * - cohortId only: all eligible shortlisted members in that cohort (must be in notification window).
+ * - userId only (applicant): that user’s eligible shortlisted rows across all window cohorts.
+ * - both: single member in that cohort.
+ * Omit both for default batch across all eligible cohorts.
  */
 export class SendShortlistingEmailsDto {
   @ApiProperty({
     required: false,
-    description:
-      'Cohort UUID; must be sent together with userId for targeted send',
+    description: 'Cohort UUID; alone = all shortlisted in cohort pending email',
   })
   @IsOptional()
   @IsUUID('4', { message: 'cohortId must be a valid UUID' })
@@ -20,9 +27,22 @@ export class SendShortlistingEmailsDto {
   @ApiProperty({
     required: false,
     description:
-      'Applicant user UUID; must be sent together with cohortId for targeted send',
+      'Applicant user UUID; alone = that user across window cohorts; with cohortId = one member',
   })
   @IsOptional()
   @IsUUID('4', { message: 'userId must be a valid UUID' })
   userId?: string;
+
+  @ApiProperty({
+    type: Number,
+    description:
+      'Optional batch size (SQL LIMIT and parallel chunk size); defaults to BATCH_SIZE env',
+    required: false,
+  })
+  @IsOptional()
+  @ValidateIf((o) => o.batchSize !== undefined && o.batchSize !== null)
+  @Type(() => Number)
+  @IsInt({ message: 'batchSize must be an integer' })
+  @Min(1, { message: 'batchSize must be at least 1' })
+  batchSize?: number;
 }

--- a/src/cohortMembers/entities/cohort-member.entity.ts
+++ b/src/cohortMembers/entities/cohort-member.entity.ts
@@ -54,9 +54,9 @@ export class CohortMembers {
   status: MemberStatus;
 
   /**
-  * Indicates whether a rejection email notification has been sent to this cohort member
-  * Used to prevent duplicate rejection email notifications
-  */
+   * For rejected members: whether the rejection email was sent.
+   * For shortlisted members: reused by send-shortlisting-emails cron to mark onStudentShortlisted sent.
+   */
   @Column({ name: 'rejection_email_sent', type: 'boolean', default: false })
   rejectionEmailSent: boolean;
 }

--- a/src/common/utils/api-id.config.ts
+++ b/src/common/utils/api-id.config.ts
@@ -56,6 +56,8 @@ export const APIID = {
   COHORT_MEMBER_DELETE: "api.cohortmember.delete",
   COHORT_MEMBER_EVALUATE_SHORTLISTING: "api.cohortmember.evaluateShortlisting",
   COHORT_MEMBER_SEND_REJECTION_EMAILS: "api.cohortmember.sendRejectionEmails",
+  COHORT_MEMBER_SEND_SHORTLISTING_EMAILS:
+    "api.cohortmember.sendShortlistingEmails",
 
   // Privilege Assignment APIs
   ASSIGNPRIVILEGE_CREATE: "api.assignprivilege.create",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cron-driven endpoint to send shortlisting emails (supports optional cohort/user filtering and configurable batch size); manual API trigger supported.
  * Cron and evaluation triggers now accept an optional cohort filter to target a single cohort.
  * New request DTOs and API identifier for shortlisting/rejection email triggers.

* **Behavior Changes**
  * Shortlisting pre-checks applicant auto-tags and auto-rejects those marked completed_alumni before rule evaluation.
  * Inline shortlisting email sending moved to the scheduled notification flow.

* **Documentation**
  * Clarified the email-sent marker comment to reflect dual use for rejections and shortlist notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->