### PR TITLE
Remove auth token for content List API to make public

### DIFF
--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -36,11 +36,11 @@ import { JwtAuthGuard } from 'src/common/guards/keycloak.guard';
 
 @ApiTags('Content')
 @Controller('content')
-@UseGuards(JwtAuthGuard)
 export class ContentController {
   constructor(private readonly contentService: ContentService) {}
 
   @Patch('update/:id')
+  @UseGuards(JwtAuthGuard)
   @ApiOperation({
     summary: 'Update existing content',
     description: 'Updates an existing content entry with the provided information.',
@@ -86,11 +86,7 @@ export class ContentController {
     summary: 'List content',
     description: 'Retrieves a list of content based on filters and pagination.',
   })
-  @ApiHeader({
-    name: 'Authorization',
-    description: 'Bearer token for authentication',
-    required: true,
-  })
+  
   @ApiHeader({
     name: 'tenantid',
     description: 'Tenant UUID',
@@ -116,6 +112,7 @@ export class ContentController {
   }
 
   @Post('create')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: 'Create new content',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Content creation and update operations now consistently require authentication. Both endpoints are now protected, ensuring only authorized users can create or modify content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->