### PR TITLE
added the statusReason column to fetch from cohortmember table

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3511,6 +3511,7 @@ export class UserService {
                     cm."createdAt" as "joinedAt",
                     cm."status" as "cohortMemberStatus",
                     cm."cohortMembershipId" as "cohortMemberId",
+                    cm."statusReason" as "statusReason",
                     batch."name" as "batchName",
                     batch."type" as "batchType",
                     batch."status" as "batchStatus",
@@ -3546,6 +3547,7 @@ export class UserService {
                   batchStatus: result.batchStatus,
                   joinedAt: result.joinedAt,
                   cohortMemberStatus: result.cohortMemberStatus,
+                  statusReason: result.statusReason,
                   cohortMemberId: result.cohortMemberId,
                   tenantId: result.tenantId,
 


### PR DESCRIPTION
Here I have added the column in query to fetch from cohortmember table, which needs in reports 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * User events now include cohort membership status reasons, providing more detailed information in event payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->