### PR TITLE
Active user should come in activation list count in referral

### DIFF
--- a/src/referrals/referrals.service.ts
+++ b/src/referrals/referrals.service.ts
@@ -138,7 +138,7 @@ export class ReferralsService {
            FROM "UserAttribution" ua
            JOIN "Users" u ON u."userId" = ua."userId"
            WHERE ua."referralEntityId" = ANY($1)
-             AND u."status" IN ('active', 'inactive')
+             AND u."status" = 'active'
            GROUP BY ua."referralEntityId"`,
           [rows.map((r) => r.id)],
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Referral signup counts now accurately track only active users, excluding inactive accounts from the metrics. This provides more precise and reliable referral performance analytics, enabling clearer insights into your referral program's actual engagement levels and effectiveness for better performance evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->