### PR TITLE
AVP Course checked and Marking completed After All course completion 

### DIFF
--- a/src/common/utils/response.messages.ts
+++ b/src/common/utils/response.messages.ts
@@ -249,6 +249,8 @@ export const API_RESPONSES = {
   PATHWAY_UPDATED_SUCCESSFULLY: "Pathway updated successfully",
   PATHWAY_NOT_FOUND: "Pathway not found",
   PATHWAY_KEY_EXISTS: "Pathway with this name already exists",
+  PATHWAY_SUBTYPE_APPLICATION_OPEN_CONFLICT:
+    "Another pathway of this subtype already has an open application window. A new pathway of the same subtype cannot be created until it closes.",
   PATHWAY_LIST_SUCCESS: "Pathways retrieved successfully",
   PATHWAY_USER_LIST_SUCCESS: "Pathway users retrieved successfully",
   PATHWAY_GET_SUCCESS: "Pathway retrieved successfully",
@@ -291,7 +293,8 @@ export const API_RESPONSES = {
   COURSE_COMPLETION_ALREADY_PROCESSED: "Course completion notification already sent for this user and course.",
   COURSE_COMPLETION_HISTORY_NOT_FOUND: "No active pathway history found for this user and course.",
   PATHWAY_COURSE_COMPLETED_PARTIAL: "Course completion recorded. Waiting for remaining courses in this pathway to be completed.",
-  PATHWAY_ALL_COURSES_COMPLETED: "All courses in this pathway are completed. Pathway marked completed and notification sent.",
+  PATHWAY_ALL_COURSES_COMPLETED: "All courses in this pathway are completed. Pathway marked completed; notification will be sent by LMS.",
+  LMS_SERVICE_UNAVAILABLE: "Could not verify course completion status with LMS. Please retry.",
 
   // Country Management Messages
   COUNTRY_LIST_SUCCESS: "Countries retrieved successfully",

--- a/src/common/utils/response.messages.ts
+++ b/src/common/utils/response.messages.ts
@@ -250,7 +250,7 @@ export const API_RESPONSES = {
   PATHWAY_NOT_FOUND: "Pathway not found",
   PATHWAY_KEY_EXISTS: "Pathway with this name already exists",
   PATHWAY_SUBTYPE_APPLICATION_OPEN_CONFLICT:
-    "Another pathway of this subtype already has an open application window. A new pathway of the same subtype cannot be created until it closes.",
+    "Another pathway of this subtype already has an open application window. A new pathway of the same subtype cannot be created for this date window.",
   PATHWAY_LIST_SUCCESS: "Pathways retrieved successfully",
   PATHWAY_USER_LIST_SUCCESS: "Pathway users retrieved successfully",
   PATHWAY_GET_SUCCESS: "Pathway retrieved successfully",

--- a/src/common/utils/response.messages.ts
+++ b/src/common/utils/response.messages.ts
@@ -288,10 +288,10 @@ export const API_RESPONSES = {
   VOLUNTEER_ELIGIBILITY_NOT_COMPLETED_ALUMNI: "User must complete the alumni pathway before applying to a volunteer or standard pathway.",
   VOLUNTEER_ELIGIBILITY_RETRIEVED: "Volunteer pathway eligibility check completed.",
   VOLUNTEER_ACTIVE_PATHWAYS_RETRIEVED: "Active volunteer pathway assignments retrieved successfully.",
-  COURSE_COMPLETION_NOTIFICATION_SENT: "Course completion notification sent and tags assigned successfully.",
   COURSE_COMPLETION_ALREADY_PROCESSED: "Course completion notification already sent for this user and course.",
   COURSE_COMPLETION_HISTORY_NOT_FOUND: "No active pathway history found for this user and course.",
-  COURSE_NOT_COMPLETED_IN_LMS: "Course is not fully completed in LMS. Tags will not be assigned until completedLesson >= noOfLesson and status is completed.",
+  PATHWAY_COURSE_COMPLETED_PARTIAL: "Course completion recorded. Waiting for remaining courses in this pathway to be completed.",
+  PATHWAY_ALL_COURSES_COMPLETED: "All courses in this pathway are completed. Pathway marked completed and notification sent.",
 
   // Country Management Messages
   COUNTRY_LIST_SUCCESS: "Countries retrieved successfully",

--- a/src/pathways/common/services/lms-client.service.ts
+++ b/src/pathways/common/services/lms-client.service.ts
@@ -447,20 +447,21 @@ export class LmsClientService {
   }
 
   /**
-   * Get the single active batch course for a VOLUNTEER pathway.
-   * Calls LMS search with isActive=true so only the currently open batch is returned.
-   * Returns the courseId string, or null if no active batch exists.
+   * Get all active batch courses for a VOLUNTEER pathway.
+   * Calls LMS search with isActive=true so only currently open batches are returned.
+   * Returns an array of course IDs (may be empty if no active batch exists).
+   * Paginated the same way as getCourseIdsForPathway; no N+1.
    *
    * LMS contract: GET /lms-service/v1/courses/search?pathwayId=X&isActive=true&status=published
    */
-  async getActiveCourseForPathway(
+  async getActiveCourseIdsForPathway(
     pathwayId: string,
     tenantId: string,
     organisationId: string
-  ): Promise<string | null> {
+  ): Promise<string[]> {
     if (!this.lmsServiceUrl) {
-      this.logger.warn(`LMS_SERVICE_URL not configured. Cannot resolve active course for pathway ${pathwayId}`);
-      return null;
+      this.logger.warn(`LMS_SERVICE_URL not configured. Cannot resolve active courses for pathway ${pathwayId}`);
+      return [];
     }
 
     const searchUrl = `${this.lmsServiceUrl}/lms-service/v1/courses/search`;
@@ -470,44 +471,78 @@ export class LmsClientService {
       'Content-Type': 'application/json',
     };
 
+    const limit = 1000;
+    const MAX_PAGES = 100;
+    const MAX_COURSES = 100000;
+    let offset = 0;
+    let allCourses: any[] = [];
+    let totalElements = 0;
+    let hasMore = true;
+    let pageCount = 0;
+
     try {
-      const res = await axios.get(searchUrl, {
-        params: {
+      while (hasMore) {
+        if (pageCount >= MAX_PAGES || allCourses.length >= MAX_COURSES) break;
+
+        const searchParams = {
           pathwayId,
           status: 'published',
           isActive: true,
-          limit: 1,
-          offset: 0,
-        },
-        headers,
-        timeout: 10000,
-        validateStatus: (status) => status < 500,
-      });
+          limit,
+          offset,
+        };
 
-      if (res.status !== 200) {
-        this.logger.warn(`LMS active-course lookup returned ${res.status} for pathway ${pathwayId}`);
-        return null;
+        const res = await axios.get(searchUrl, {
+          params: searchParams,
+          headers,
+          timeout: 10000,
+          validateStatus: (status) => status < 500,
+        });
+
+        if (res.status !== 200) {
+          if (allCourses.length === 0) {
+            this.logger.warn(`LMS active-course lookup returned ${res.status} for pathway ${pathwayId}`);
+            return [];
+          }
+          break;
+        }
+
+        const responseData = res.data?.result || res.data;
+        const courses = responseData?.courses || [];
+        totalElements = responseData?.totalElements || 0;
+
+        if (courses.length === 0) break;
+
+        if (courses.length > 0 && allCourses.length > 0) {
+          const firstId = courses[0]?.courseId || courses[0]?.id;
+          const lastId =
+            allCourses[allCourses.length - 1]?.courseId ||
+            allCourses[allCourses.length - 1]?.id;
+          if (firstId === lastId) break;
+        }
+
+        allCourses = allCourses.concat(courses);
+        pageCount++;
+        hasMore =
+          courses.length === limit &&
+          (totalElements === 0 || offset + limit < totalElements);
+        if (hasMore) offset += limit;
       }
 
-      const responseData = res.data?.result || res.data;
-      const courses: any[] = responseData?.courses || [];
+      const courseIds = allCourses
+        .map((c: any) => c.courseId || c.id || c.course_id)
+        .filter(Boolean)
+        .filter((id: string) => LmsClientService.UUID_REGEX.test(id));
 
-      if (courses.length === 0) {
+      if (courseIds.length === 0) {
         this.logger.warn(`No active batch course found in LMS for pathway ${pathwayId}`);
-        return null;
       }
 
-      const courseId = courses[0]?.courseId || courses[0]?.id || courses[0]?.course_id;
-      if (!courseId || !LmsClientService.UUID_REGEX.test(courseId)) {
-        this.logger.warn(`Active course for pathway ${pathwayId} has invalid ID: ${courseId}`);
-        return null;
-      }
-
-      return courseId;
+      return courseIds;
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`Failed to get active course for pathway ${pathwayId}: ${msg}`);
-      return null;
+      this.logger.error(`Failed to get active courses for pathway ${pathwayId}: ${msg}`);
+      return [];
     }
   }
 
@@ -649,6 +684,57 @@ export class LmsClientService {
       const msg = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to get course progress for user ${userId} course ${courseId}: ${msg}`);
       return null;
+    }
+  }
+
+  /**
+   * Aggregate completion status for every course tied to a pathway, for one user.
+   * Single HTTP call, regardless of how many courses the pathway has — LMS resolves
+   * the course list and completion counts server-side (no per-course looping here).
+   *
+   * LMS contract: GET /lms-service/v1/tracking/pathway-completion-status?pathwayId=X&userId=Y
+   */
+  async getPathwayCompletionStatus(
+    pathwayId: string,
+    userId: string,
+    tenantId: string,
+    organisationId: string
+  ): Promise<{ totalCourses: number; completedCourses: number; allCompleted: boolean }> {
+    if (!this.lmsServiceUrl) {
+      this.logger.warn('LMS_SERVICE_URL not configured. Cannot resolve pathway completion status.');
+      return { totalCourses: 0, completedCourses: 0, allCompleted: false };
+    }
+
+    const url = `${this.lmsServiceUrl}/lms-service/v1/tracking/pathway-completion-status`;
+    const headers = {
+      tenantid: tenantId,
+      organisationid: organisationId,
+      'Content-Type': 'application/json',
+    };
+
+    try {
+      const res = await axios.get(url, {
+        params: { pathwayId, userId },
+        headers,
+        timeout: 10000,
+        validateStatus: (status) => status < 500,
+      });
+
+      if (res.status !== 200) {
+        this.logger.warn(`LMS pathway completion status returned ${res.status} for pathway ${pathwayId} user ${userId}`);
+        return { totalCourses: 0, completedCourses: 0, allCompleted: false };
+      }
+
+      const data = res.data?.result || res.data;
+      return {
+        totalCourses: Number(data?.totalCourses ?? 0),
+        completedCourses: Number(data?.completedCourses ?? 0),
+        allCompleted: Boolean(data?.allCompleted),
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to get pathway completion status for pathway ${pathwayId} user ${userId}: ${msg}`);
+      return { totalCourses: 0, completedCourses: 0, allCompleted: false };
     }
   }
 

--- a/src/pathways/common/services/lms-client.service.ts
+++ b/src/pathways/common/services/lms-client.service.ts
@@ -449,8 +449,11 @@ export class LmsClientService {
   /**
    * Get all active batch courses for a VOLUNTEER pathway.
    * Calls LMS search with isActive=true so only currently open batches are returned.
-   * Returns an array of course IDs (may be empty if no active batch exists).
    * Paginated the same way as getCourseIdsForPathway; no N+1.
+   *
+   * Returns `null` if the fetch is incomplete/failed (non-200 mid-pagination, network
+   * error) — callers must treat this as "unknown", never as "zero active courses".
+   * Returns `[]` only when LMS genuinely reports no matching courses.
    *
    * LMS contract: GET /lms-service/v1/courses/search?pathwayId=X&isActive=true&status=published
    */
@@ -458,10 +461,10 @@ export class LmsClientService {
     pathwayId: string,
     tenantId: string,
     organisationId: string
-  ): Promise<string[]> {
+  ): Promise<string[] | null> {
     if (!this.lmsServiceUrl) {
       this.logger.warn(`LMS_SERVICE_URL not configured. Cannot resolve active courses for pathway ${pathwayId}`);
-      return [];
+      return null;
     }
 
     const searchUrl = `${this.lmsServiceUrl}/lms-service/v1/courses/search`;
@@ -475,14 +478,16 @@ export class LmsClientService {
     const MAX_PAGES = 100;
     const MAX_COURSES = 100000;
     let offset = 0;
-    let allCourses: any[] = [];
+    // Set-based dedupe: catches a repeated page (e.g. LMS ignoring `offset`) even when
+    // it's a full multi-item duplicate, not just a single-ID boundary overlap.
+    const seenIds = new Set<string>();
     let totalElements = 0;
     let hasMore = true;
     let pageCount = 0;
 
     try {
       while (hasMore) {
-        if (pageCount >= MAX_PAGES || allCourses.length >= MAX_COURSES) break;
+        if (pageCount >= MAX_PAGES || seenIds.size >= MAX_COURSES) break;
 
         const searchParams = {
           pathwayId,
@@ -500,11 +505,8 @@ export class LmsClientService {
         });
 
         if (res.status !== 200) {
-          if (allCourses.length === 0) {
-            this.logger.warn(`LMS active-course lookup returned ${res.status} for pathway ${pathwayId}`);
-            return [];
-          }
-          break;
+          this.logger.warn(`LMS active-course lookup returned ${res.status} for pathway ${pathwayId} at offset ${offset} — treating as incomplete`);
+          return null;
         }
 
         const responseData = res.data?.result || res.data;
@@ -513,15 +515,15 @@ export class LmsClientService {
 
         if (courses.length === 0) break;
 
-        if (courses.length > 0 && allCourses.length > 0) {
-          const firstId = courses[0]?.courseId || courses[0]?.id;
-          const lastId =
-            allCourses[allCourses.length - 1]?.courseId ||
-            allCourses[allCourses.length - 1]?.id;
-          if (firstId === lastId) break;
-        }
+        const pageIds: string[] = courses
+          .map((c: any) => c.courseId || c.id || c.course_id)
+          .filter(Boolean)
+          .filter((id: string) => LmsClientService.UUID_REGEX.test(id));
 
-        allCourses = allCourses.concat(courses);
+        const newIds = pageIds.filter((id) => !seenIds.has(id));
+        if (newIds.length === 0) break; // page contributed nothing new — stop instead of looping forever
+
+        newIds.forEach((id) => seenIds.add(id));
         pageCount++;
         hasMore =
           courses.length === limit &&
@@ -529,11 +531,7 @@ export class LmsClientService {
         if (hasMore) offset += limit;
       }
 
-      const courseIds = allCourses
-        .map((c: any) => c.courseId || c.id || c.course_id)
-        .filter(Boolean)
-        .filter((id: string) => LmsClientService.UUID_REGEX.test(id));
-
+      const courseIds = Array.from(seenIds);
       if (courseIds.length === 0) {
         this.logger.warn(`No active batch course found in LMS for pathway ${pathwayId}`);
       }
@@ -542,7 +540,7 @@ export class LmsClientService {
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to get active courses for pathway ${pathwayId}: ${msg}`);
-      return [];
+      return null;
     }
   }
 
@@ -699,10 +697,10 @@ export class LmsClientService {
     userId: string,
     tenantId: string,
     organisationId: string
-  ): Promise<{ totalCourses: number; completedCourses: number; allCompleted: boolean }> {
+  ): Promise<{ totalCourses: number; completedCourses: number; allCompleted: boolean } | null> {
     if (!this.lmsServiceUrl) {
       this.logger.warn('LMS_SERVICE_URL not configured. Cannot resolve pathway completion status.');
-      return { totalCourses: 0, completedCourses: 0, allCompleted: false };
+      return null;
     }
 
     const url = `${this.lmsServiceUrl}/lms-service/v1/tracking/pathway-completion-status`;
@@ -720,9 +718,11 @@ export class LmsClientService {
         validateStatus: (status) => status < 500,
       });
 
+      // Non-200 is a genuine LMS failure, not "zero courses completed" — the caller
+      // must not treat this the same as legitimate partial progress.
       if (res.status !== 200) {
         this.logger.warn(`LMS pathway completion status returned ${res.status} for pathway ${pathwayId} user ${userId}`);
-        return { totalCourses: 0, completedCourses: 0, allCompleted: false };
+        return null;
       }
 
       const data = res.data?.result || res.data;
@@ -734,7 +734,7 @@ export class LmsClientService {
     } catch (error) {
       const msg = error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to get pathway completion status for pathway ${pathwayId} user ${userId}: ${msg}`);
-      return { totalCourses: 0, completedCourses: 0, allCompleted: false };
+      return null;
     }
   }
 

--- a/src/pathways/pathway/dto/list-pathway.dto.ts
+++ b/src/pathways/pathway/dto/list-pathway.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsOptional, IsString, IsUUID, IsObject, ValidateNested, IsEnum, IsInt, Min } from 'class-validator';
+import { IsBoolean, IsOptional, IsString, IsUUID, IsObject, ValidateNested, IsEnum, IsIn, IsInt, Min } from 'class-validator';
 import { Expose, Type } from 'class-transformer';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { PathwayType } from '../entities/pathway.entity';
@@ -70,6 +70,17 @@ class PathwayFiltersDto {
   @IsInt()
   @Min(1970)
   applicationYear?: number;
+
+  @ApiPropertyOptional({
+    description:
+      "Filter VOLUNTEER pathways by computed lifecycle status: 'completed' = application_closing_date has passed, 'expired' = volunteer_valid_until has passed. Used by the admin list's Completed/Expired tabs.",
+    enum: ['completed', 'expired'],
+    example: 'completed',
+  })
+  @Expose()
+  @IsOptional()
+  @IsIn(['completed', 'expired'])
+  computedStatus?: 'completed' | 'expired';
 }
 export class ListPathwayDto extends PaginationDto {
   @ApiPropertyOptional({

--- a/src/pathways/pathway/pathways.controller.ts
+++ b/src/pathways/pathway/pathways.controller.ts
@@ -583,11 +583,11 @@ export class PathwaysController {
   @ApiParam({ name: "id", description: "Pathway UUID", format: "uuid" })
   @ApiResponse({
     status: 200,
-    description: "Active course resolved",
+    description: "Active course(s) resolved",
     schema: {
       example: {
         pathwayId: "pw4-uuid-cal-pathway",
-        courseId: "c102-uuid-cal-batch2-2025",
+        courseIds: ["c102-uuid-cal-batch2-2025"],
       },
     },
   })
@@ -715,12 +715,14 @@ export class PathwaysController {
   async courseCompleted(
     @Body() dto: CourseCompletionWebhookDto,
     @Headers("tenantid") tenantId: string,
+    @Headers("organisationid") organisationId: string,
     @Res() response: Response
   ): Promise<Response> {
     if (!tenantId || !isUUID(tenantId)) {
       throw new BadRequestException(API_RESPONSES.TENANTID_VALIDATION);
     }
-    return this.pathwaysService.handleCourseCompletion(dto, response);
+    const orgId = (process.env.DEFAULT_ORGANISATION_ID || organisationId || '').trim();
+    return this.pathwaysService.handleCourseCompletion(dto, response, tenantId, orgId);
   }
 
   /**

--- a/src/pathways/pathway/pathways.controller.ts
+++ b/src/pathways/pathway/pathways.controller.ts
@@ -722,6 +722,9 @@ export class PathwaysController {
       throw new BadRequestException(API_RESPONSES.TENANTID_VALIDATION);
     }
     const orgId = (process.env.DEFAULT_ORGANISATION_ID || organisationId || '').trim();
+    if (!orgId) {
+      throw new BadRequestException(API_RESPONSES.ORGANISATIONID_REQUIRED);
+    }
     return this.pathwaysService.handleCourseCompletion(dto, response, tenantId, orgId);
   }
 

--- a/src/pathways/pathway/pathways.service.ts
+++ b/src/pathways/pathway/pathways.service.ts
@@ -283,6 +283,40 @@ export class PathwaysService {
   }
 
   /**
+   * True if any other VOLUNTEER pathway of the same subtype has an application
+   * window overlapping [openingDate, closingDate] — compares full ranges (not just
+   * "is anything currently open") so overlaps are caught whether the conflicting
+   * window is in the future or already backdated. NULL opening/closing bounds are
+   * treated as open-ended (no lower/upper bound).
+   */
+  private async hasSubtypeWindowConflict(
+    subtype: string,
+    openingDate: string | Date | null | undefined,
+    closingDate: string | Date | null | undefined,
+    excludePathwayId: string | null = null,
+  ): Promise<boolean> {
+    const conflict = await this.pathwayRepository
+      .createQueryBuilder('pathway')
+      .where('pathway.type = :swcType', { swcType: PathwayType.VOLUNTEER })
+      .andWhere('pathway.subtype = :swcSubtype', { swcSubtype: subtype })
+      .andWhere('(:swcExcludeId::uuid IS NULL OR pathway.id != :swcExcludeId)', {
+        swcExcludeId: excludePathwayId,
+      })
+      .andWhere(
+        '(pathway.application_closing_date IS NULL OR :swcNewOpening::timestamptz IS NULL OR :swcNewOpening::timestamptz <= pathway.application_closing_date)',
+        { swcNewOpening: openingDate ?? null }
+      )
+      .andWhere(
+        '(:swcNewClosing::timestamptz IS NULL OR pathway.application_opening_date IS NULL OR pathway.application_opening_date <= :swcNewClosing::timestamptz)',
+        { swcNewClosing: closingDate ?? null }
+      )
+      .select(['pathway.id'])
+      .getOne();
+
+    return !!conflict;
+  }
+
+  /**
    * Create a new pathway
    * Optimized: Single query with conflict check and batch tag validation
    */
@@ -350,24 +384,20 @@ export class PathwaysService {
         }
       }
 
-      // Block creating a new pathway of a given VOLUNTEER subtype (e.g. CAL) while
-      // another pathway of the same subtype still has an open application window,
-      // so two application windows for the same subtype can never overlap.
+      // Block creating a new pathway of a given VOLUNTEER subtype (e.g. CAL) whose
+      // application window overlaps another pathway of the same subtype, so two
+      // application windows for the same subtype can never overlap.
       if (
         (createPathwayDto.type ?? PathwayType.STANDARD) === PathwayType.VOLUNTEER &&
         createPathwayDto.subtype
       ) {
-        const openSubtypePathway = await this.pathwayRepository
-          .createQueryBuilder('pathway')
-          .where('pathway.type = :type', { type: PathwayType.VOLUNTEER })
-          .andWhere('pathway.subtype = :subtype', { subtype: createPathwayDto.subtype })
-          .andWhere(
-            '(pathway.application_closing_date IS NULL OR pathway.application_closing_date > CURRENT_TIMESTAMP)'
-          )
-          .select(['pathway.id'])
-          .getOne();
+        const hasConflict = await this.hasSubtypeWindowConflict(
+          createPathwayDto.subtype,
+          createPathwayDto.application_opening_date,
+          createPathwayDto.application_closing_date,
+        );
 
-        if (openSubtypePathway) {
+        if (hasConflict) {
           return APIResponse.error(
             response,
             apiId,
@@ -1161,6 +1191,26 @@ export class PathwaysService {
             response, apiId, API_RESPONSES.BAD_REQUEST,
             'application_closing_date must be on or after application_opening_date', HttpStatus.BAD_REQUEST
           );
+        }
+
+        // Same overlap invariant as create(): this subtype's application window
+        // must not overlap another pathway of the same subtype's window.
+        const effectiveSubtype = updatePathwayDto.subtype !== undefined ? updatePathwayDto.subtype : existingPathway.subtype;
+        if (effectiveSubtype) {
+          const hasConflict = await this.hasSubtypeWindowConflict(
+            effectiveSubtype,
+            openingDate,
+            closingDate,
+            id,
+          );
+
+          if (hasConflict) {
+            return APIResponse.error(
+              response, apiId, API_RESPONSES.CONFLICT,
+              API_RESPONSES.PATHWAY_SUBTYPE_APPLICATION_OPEN_CONFLICT,
+              HttpStatus.CONFLICT
+            );
+          }
         }
 
         if (updatePathwayDto.subtype !== undefined) {

--- a/src/pathways/pathway/pathways.service.ts
+++ b/src/pathways/pathway/pathways.service.ts
@@ -350,6 +350,34 @@ export class PathwaysService {
         }
       }
 
+      // Block creating a new pathway of a given VOLUNTEER subtype (e.g. CAL) while
+      // another pathway of the same subtype still has an open application window,
+      // so two application windows for the same subtype can never overlap.
+      if (
+        (createPathwayDto.type ?? PathwayType.STANDARD) === PathwayType.VOLUNTEER &&
+        createPathwayDto.subtype
+      ) {
+        const openSubtypePathway = await this.pathwayRepository
+          .createQueryBuilder('pathway')
+          .where('pathway.type = :type', { type: PathwayType.VOLUNTEER })
+          .andWhere('pathway.subtype = :subtype', { subtype: createPathwayDto.subtype })
+          .andWhere(
+            '(pathway.application_closing_date IS NULL OR pathway.application_closing_date > CURRENT_TIMESTAMP)'
+          )
+          .select(['pathway.id'])
+          .getOne();
+
+        if (openSubtypePathway) {
+          return APIResponse.error(
+            response,
+            apiId,
+            API_RESPONSES.CONFLICT,
+            API_RESPONSES.PATHWAY_SUBTYPE_APPLICATION_OPEN_CONFLICT,
+            HttpStatus.CONFLICT
+          );
+        }
+      }
+
       // 3. Handle auto-increment for display_order with retry logic for TOCTOU race conditions
       const MAX_RETRIES = 3;
       for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
@@ -718,6 +746,15 @@ export class PathwaysService {
             { applicationYear: Number(filters.applicationYear) }
           );
         }
+        if (filters.computedStatus === 'completed') {
+          queryBuilder.andWhere(
+            "pathway.application_closing_date IS NOT NULL AND pathway.application_closing_date <= CURRENT_TIMESTAMP"
+          );
+        } else if (filters.computedStatus === 'expired') {
+          queryBuilder.andWhere(
+            "pathway.volunteer_valid_until IS NOT NULL AND pathway.volunteer_valid_until <= CURRENT_TIMESTAMP"
+          );
+        }
 
         // Apply ordering
         queryBuilder.orderBy("pathway.display_order", "ASC");
@@ -747,6 +784,15 @@ export class PathwaysService {
           whereCondition.application_opening_date = Raw(
             alias => `EXTRACT(YEAR FROM ${alias}) = :year`,
             { year: Number(filters.applicationYear) }
+          );
+        }
+        if (filters.computedStatus === 'completed') {
+          whereCondition.application_closing_date = Raw(
+            alias => `${alias} IS NOT NULL AND ${alias} <= CURRENT_TIMESTAMP`
+          );
+        } else if (filters.computedStatus === 'expired') {
+          whereCondition.volunteer_valid_until = Raw(
+            alias => `${alias} IS NOT NULL AND ${alias} <= CURRENT_TIMESTAMP`
           );
         }
 
@@ -1482,6 +1528,13 @@ export class PathwaysService {
 
       // 3. Enroll user in all active LMS courses for this pathway (auto-resolve from LMS)
       const resolvedCourseIds = await this.lmsClientService.getActiveCourseIdsForPathway(pathway.id, tenantId, organisationId);
+      if (resolvedCourseIds === null) {
+        return APIResponse.error(
+          response, apiId, API_RESPONSES.LMS_SERVICE_UNAVAILABLE,
+          'Could not verify active courses for this pathway in LMS. Please try again.',
+          HttpStatus.SERVICE_UNAVAILABLE
+        );
+      }
       if (resolvedCourseIds.length === 0) {
         return APIResponse.error(
           response, apiId, API_RESPONSES.NOT_FOUND,
@@ -1594,17 +1647,36 @@ export class PathwaysService {
         return APIResponse.success(response, apiId, { items, count: items.length }, HttpStatus.OK, 'Active volunteer pathways retrieved successfully');
       }
 
-      // STANDARD (default): return single active record
-      const whereCondition: any = {
-        user_id: userId,
-        ...(pathwayId ? { pathway_id: pathwayId } : { is_active: true }),
-      };
+      // STANDARD (default): return single active record.
+      // Must join and filter on pathway.type = STANDARD — otherwise an active
+      // VOLUNTEER assignment (e.g. a CAL pathway) would be picked up here too,
+      // making every STANDARD pathway look like it has an active pathway to switch from.
+      const qb = this.userPathwayHistoryRepository
+        .createQueryBuilder('h')
+        .innerJoin('h.pathway', 'pw')
+        .where('h.user_id = :userId', { userId })
+        .andWhere('pw.type = :type', { type: PathwayType.STANDARD });
 
-      const userPathway = await this.userPathwayHistoryRepository.findOne({
-        where: whereCondition,
-        order: { activated_at: 'DESC' },
-        select: ['id', 'pathway_id', 'activated_at', 'deactivated_at', 'completed_at', 'user_goal', 'is_active', 'updated_by', 'status'],
-      });
+      if (pathwayId) {
+        qb.andWhere('h.pathway_id = :pathwayId', { pathwayId });
+      } else {
+        qb.andWhere('h.is_active = :isActive', { isActive: true });
+      }
+
+      const userPathway = await qb
+        .orderBy('h.activated_at', 'DESC')
+        .select([
+          'h.id',
+          'h.pathway_id',
+          'h.activated_at',
+          'h.deactivated_at',
+          'h.completed_at',
+          'h.user_goal',
+          'h.is_active',
+          'h.updated_by',
+          'h.status',
+        ])
+        .getOne();
 
       if (!userPathway) {
         const message = pathwayId ? 'Specified pathway assignment not found for this user' : 'No active pathway found for this user';
@@ -1991,6 +2063,10 @@ export class PathwaysService {
 
       const courseIds = await this.lmsClientService.getActiveCourseIdsForPathway(pathwayId, tenantId, organisationId);
 
+      if (courseIds === null) {
+        return APIResponse.error(response, apiId, API_RESPONSES.LMS_SERVICE_UNAVAILABLE, 'Could not verify active courses for this pathway in LMS. Please try again.', HttpStatus.SERVICE_UNAVAILABLE);
+      }
+
       if (courseIds.length === 0) {
         return APIResponse.error(response, apiId, API_RESPONSES.NOT_FOUND, 'No active batch course found for this pathway in LMS.', HttpStatus.NOT_FOUND);
       }
@@ -2219,6 +2295,17 @@ export class PathwaysService {
       const completion = await this.lmsClientService.getPathwayCompletionStatus(
         dto.pathwayId, dto.userId, tenantId, organisationId
       );
+
+      // null means LMS was unreachable/erroring — a genuine failure, not "0 courses
+      // done yet". Surface a retriable error so LMS's webhook retry (3 attempts) kicks
+      // in, rather than silently acknowledging a lost completion check as "partial".
+      if (completion === null) {
+        return APIResponse.error(
+          response, apiId, API_RESPONSES.LMS_SERVICE_UNAVAILABLE,
+          'Could not verify course completion status with LMS. Please retry.',
+          HttpStatus.SERVICE_UNAVAILABLE
+        );
+      }
 
       if (!completion.allCompleted) {
         return APIResponse.success(

--- a/src/pathways/pathway/pathways.service.ts
+++ b/src/pathways/pathway/pathways.service.ts
@@ -293,24 +293,27 @@ export class PathwaysService {
     subtype: string,
     openingDate: string | Date | null | undefined,
     closingDate: string | Date | null | undefined,
-    excludePathwayId: string | null = null,
+    excludePathwayId: string | null = null
   ): Promise<boolean> {
     const conflict = await this.pathwayRepository
-      .createQueryBuilder('pathway')
-      .where('pathway.type = :swcType', { swcType: PathwayType.VOLUNTEER })
-      .andWhere('pathway.subtype = :swcSubtype', { swcSubtype: subtype })
-      .andWhere('(:swcExcludeId::uuid IS NULL OR pathway.id != :swcExcludeId)', {
-        swcExcludeId: excludePathwayId,
-      })
+      .createQueryBuilder("pathway")
+      .where("pathway.type = :swcType", { swcType: PathwayType.VOLUNTEER })
+      .andWhere("pathway.subtype = :swcSubtype", { swcSubtype: subtype })
       .andWhere(
-        '(pathway.application_closing_date IS NULL OR :swcNewOpening::timestamptz IS NULL OR :swcNewOpening::timestamptz <= pathway.application_closing_date)',
+        "(:swcExcludeId::uuid IS NULL OR pathway.id != :swcExcludeId)",
+        {
+          swcExcludeId: excludePathwayId,
+        }
+      )
+      .andWhere(
+        "(pathway.application_closing_date IS NULL OR :swcNewOpening::timestamptz IS NULL OR :swcNewOpening::timestamptz <= pathway.application_closing_date)",
         { swcNewOpening: openingDate ?? null }
       )
       .andWhere(
-        '(:swcNewClosing::timestamptz IS NULL OR pathway.application_opening_date IS NULL OR pathway.application_opening_date <= :swcNewClosing::timestamptz)',
+        "(:swcNewClosing::timestamptz IS NULL OR pathway.application_opening_date IS NULL OR pathway.application_opening_date <= :swcNewClosing::timestamptz)",
         { swcNewClosing: closingDate ?? null }
       )
-      .select(['pathway.id'])
+      .select(["pathway.id"])
       .getOne();
 
     return !!conflict;
@@ -394,7 +397,7 @@ export class PathwaysService {
         const hasConflict = await this.hasSubtypeWindowConflict(
           createPathwayDto.subtype,
           createPathwayDto.application_opening_date,
-          createPathwayDto.application_closing_date,
+          createPathwayDto.application_closing_date
         );
 
         if (hasConflict) {
@@ -1195,13 +1198,16 @@ export class PathwaysService {
 
         // Same overlap invariant as create(): this subtype's application window
         // must not overlap another pathway of the same subtype's window.
-        const effectiveSubtype = updatePathwayDto.subtype !== undefined ? updatePathwayDto.subtype : existingPathway.subtype;
+        const effectiveSubtype =
+          updatePathwayDto.subtype !== undefined
+            ? updatePathwayDto.subtype
+            : existingPathway.subtype;
         if (effectiveSubtype) {
           const hasConflict = await this.hasSubtypeWindowConflict(
             effectiveSubtype,
             openingDate,
             closingDate,
-            id,
+            id
           );
 
           if (hasConflict) {

--- a/src/pathways/pathway/pathways.service.ts
+++ b/src/pathways/pathway/pathways.service.ts
@@ -1480,16 +1480,16 @@ export class PathwaysService {
         }
       }
 
-      // 3. Enroll user in LMS course for this pathway (auto-resolve from LMS)
-      const resolvedCourseId = await this.lmsClientService.getActiveCourseForPathway(pathway.id, tenantId, organisationId);
-      if (!resolvedCourseId) {
+      // 3. Enroll user in all active LMS courses for this pathway (auto-resolve from LMS)
+      const resolvedCourseIds = await this.lmsClientService.getActiveCourseIdsForPathway(pathway.id, tenantId, organisationId);
+      if (resolvedCourseIds.length === 0) {
         return APIResponse.error(
           response, apiId, API_RESPONSES.NOT_FOUND,
           'No active batch course found for this pathway in LMS.',
           HttpStatus.NOT_FOUND
         );
       }
-      const enrollResult = await this.lmsClientService.enrollUserToCourses(userId, [resolvedCourseId], tenantId, organisationId);
+      const enrollResult = await this.lmsClientService.enrollUserToCourses(userId, resolvedCourseIds, tenantId, organisationId);
       if (!enrollResult.success) {
         return APIResponse.error(
           response, apiId, API_RESPONSES.BAD_REQUEST,
@@ -1989,13 +1989,13 @@ export class PathwaysService {
         return APIResponse.error(response, apiId, API_RESPONSES.NOT_FOUND, API_RESPONSES.PATHWAY_NOT_FOUND, HttpStatus.NOT_FOUND);
       }
 
-      const courseId = await this.lmsClientService.getActiveCourseForPathway(pathwayId, tenantId, organisationId);
+      const courseIds = await this.lmsClientService.getActiveCourseIdsForPathway(pathwayId, tenantId, organisationId);
 
-      if (!courseId) {
+      if (courseIds.length === 0) {
         return APIResponse.error(response, apiId, API_RESPONSES.NOT_FOUND, 'No active batch course found for this pathway in LMS.', HttpStatus.NOT_FOUND);
       }
 
-      return APIResponse.success(response, apiId, { pathwayId, courseId }, HttpStatus.OK, 'Active course resolved successfully');
+      return APIResponse.success(response, apiId, { pathwayId, courseIds }, HttpStatus.OK, 'Active course(s) resolved successfully');
     } catch (error) {
       const errorMessage = error.message || API_RESPONSES.INTERNAL_SERVER_ERROR;
       LoggerUtil.error(`${API_RESPONSES.SERVER_ERROR}`, `Error fetching active course: ${errorMessage}`, apiId);
@@ -2163,7 +2163,9 @@ export class PathwaysService {
    */
   async handleCourseCompletion(
     dto: CourseCompletionWebhookDto,
-    response: Response
+    response: Response,
+    tenantId: string,
+    organisationId: string
   ): Promise<Response> {
     const apiId = APIID.PATHWAY_COURSE_COMPLETION_WEBHOOK;
     try {
@@ -2191,10 +2193,14 @@ export class PathwaysService {
         );
       }
 
-      if (record.pathway.type !== PathwayType.VOLUNTEER) {
+      const pathwayType = record.pathway.type;
+
+      // pathwayType is always returned so LMS knows whether to still send its own
+      // per-course email (skipped for VOLUNTEER — handled by the aggregate check below).
+      if (pathwayType !== PathwayType.VOLUNTEER) {
         return APIResponse.success(
           response, apiId,
-          { processed: false, reason: 'Not a VOLUNTEER pathway — no tag assignment needed' },
+          { processed: false, pathwayType, reason: 'Not a VOLUNTEER pathway — no aggregation needed' },
           HttpStatus.OK, 'Skipped'
         );
       }
@@ -2203,8 +2209,28 @@ export class PathwaysService {
       if (record.status !== PathwayHistoryStatus.ACTIVE) {
         return APIResponse.success(
           response, apiId,
-          { processed: false, historyId: record.id, status: record.status },
+          { processed: false, pathwayType, historyId: record.id, status: record.status },
           HttpStatus.OK, API_RESPONSES.COURSE_COMPLETION_ALREADY_PROCESSED
+        );
+      }
+
+      // Single aggregate LMS call — no per-course loop — to check whether every
+      // course tied to this pathway is now complete for this user.
+      const completion = await this.lmsClientService.getPathwayCompletionStatus(
+        dto.pathwayId, dto.userId, tenantId, organisationId
+      );
+
+      if (!completion.allCompleted) {
+        return APIResponse.success(
+          response, apiId,
+          {
+            processed: false,
+            pathwayType,
+            historyId: record.id,
+            totalCourses: completion.totalCourses,
+            completedCourses: completion.completedCourses,
+          },
+          HttpStatus.OK, API_RESPONSES.PATHWAY_COURSE_COMPLETED_PARTIAL
         );
       }
 
@@ -2227,20 +2253,24 @@ export class PathwaysService {
       if ((result.affected ?? 0) === 0) {
         return APIResponse.success(
           response, apiId,
-          { processed: false, historyId: record.id },
+          { processed: false, pathwayType, historyId: record.id },
           HttpStatus.OK, API_RESPONSES.COURSE_COMPLETION_ALREADY_PROCESSED
         );
       }
 
+      // Notification itself is sent by LMS (same place the per-course email lives) —
+      // this response just confirms completion so LMS knows to trigger it.
       return APIResponse.success(response, apiId, {
         historyId: record.id,
         userId: dto.userId,
         pathwayId: record.pathway_id,
+        pathwayType,
+        allCoursesCompleted: true,
         subtype: record.pathway.subtype ?? null,
         status: PathwayHistoryStatus.COMPLETED,
         completedAt: now.toISOString(),
         volunteerValidUntil: record.pathway.volunteer_valid_until?.toISOString() ?? null,
-      }, HttpStatus.OK, API_RESPONSES.COURSE_COMPLETION_NOTIFICATION_SENT);
+      }, HttpStatus.OK, API_RESPONSES.PATHWAY_ALL_COURSES_COMPLETED);
     } catch (error) {
       const errorMessage = error.message || API_RESPONSES.INTERNAL_SERVER_ERROR;
       LoggerUtil.error(`${API_RESPONSES.SERVER_ERROR}`, `Course completion API error: ${errorMessage}`, apiId);

--- a/src/pathways/pathway/pathways.service.ts
+++ b/src/pathways/pathway/pathways.service.ts
@@ -622,13 +622,19 @@ export class PathwaysService {
     );
     try {
       const cacheKey = this.generatePathwayListCacheKey(tenantId, organisationId, listPathwayDto);
+      // computedStatus ('completed'/'expired') is evaluated against CURRENT_TIMESTAMP, so a
+      // cached result can go stale the moment a pathway crosses that time boundary — bypass
+      // caching entirely for this filter rather than serving a time-sensitive stale list.
+      const bypassCache = !!(listPathwayDto as any).filters?.computedStatus;
       let cachedResult: { count: number; limit: number; offset: number; items: any[] } | null = null;
-      try {
-        cachedResult = await this.cacheService.get<{ count: number; limit: number; offset: number; items: any[] }>(cacheKey);
-      } catch (cacheReadError: any) {
-        this.logger.warn(
-          `Pathway list cache read failed, falling through to DB: ${cacheReadError?.message || cacheReadError}`
-        );
+      if (!bypassCache) {
+        try {
+          cachedResult = await this.cacheService.get<{ count: number; limit: number; offset: number; items: any[] }>(cacheKey);
+        } catch (cacheReadError: any) {
+          this.logger.warn(
+            `Pathway list cache read failed, falling through to DB: ${cacheReadError?.message || cacheReadError}`
+          );
+        }
       }
       if (cachedResult) {
         this.logger.debug(`Cache HIT for pathway list: ${cacheKey}`);
@@ -900,7 +906,9 @@ export class PathwaysService {
             tag_ids: (tags || []).map((t: { id: string }) => t.id),
           })),
         };
-        await this.cacheService.set(cacheKey, resultForCache, pathwayListCacheTtl);
+        if (!bypassCache) {
+          await this.cacheService.set(cacheKey, resultForCache, pathwayListCacheTtl);
+        }
       } catch (cacheError: any) {
         this.logger.warn(
           `Failed to cache pathway list result: ${cacheError?.message || cacheError}`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Volunteer pathway assignments now enroll participants in all active LMS course IDs for the pathway.
  * Added pathway-level course completion aggregation, including partial completion and “all courses completed” outcomes.
  * Added a `computedStatus` (completed/expired) filter for volunteer pathway listing, with updated API documentation.

* **Bug Fixes**
  * Prevents creation or update of volunteer pathways when subtype application windows overlap.
  * Active-course responses and webhook course-completion handling now consistently support multiple course IDs, with clearer LMS unavailability vs no matches semantics.

* **Documentation**
  * Updated the active-course endpoint response example to show an array of course IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->