### PR TITLE
TASK #00000 : filter inactive pathways to excluded from the conflict check

### DIFF
--- a/src/pathways/pathway/pathways.service.ts
+++ b/src/pathways/pathway/pathways.service.ts
@@ -299,6 +299,7 @@ export class PathwaysService {
       .createQueryBuilder("pathway")
       .where("pathway.type = :swcType", { swcType: PathwayType.VOLUNTEER })
       .andWhere("pathway.subtype = :swcSubtype", { swcSubtype: subtype })
+      .andWhere("pathway.is_active = true")
       .andWhere(
         "(:swcExcludeId::uuid IS NULL OR pathway.id != :swcExcludeId)",
         {
@@ -392,7 +393,8 @@ export class PathwaysService {
       // application windows for the same subtype can never overlap.
       if (
         (createPathwayDto.type ?? PathwayType.STANDARD) === PathwayType.VOLUNTEER &&
-        createPathwayDto.subtype
+        createPathwayDto.subtype &&
+        (createPathwayDto.is_active ?? true)
       ) {
         const hasConflict = await this.hasSubtypeWindowConflict(
           createPathwayDto.subtype,
@@ -1202,7 +1204,8 @@ export class PathwaysService {
           updatePathwayDto.subtype !== undefined
             ? updatePathwayDto.subtype
             : existingPathway.subtype;
-        if (effectiveSubtype) {
+        const effectiveIsActive = updatePathwayDto.is_active ?? existingPathway.is_active;
+        if (effectiveSubtype && effectiveIsActive) {
           const hasConflict = await this.hasSubtypeWindowConflict(
             effectiveSubtype,
             openingDate,


### PR DESCRIPTION
…check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volunteer pathway application-window conflict detection.
  * Conflicts are now checked only against active pathways and when the pathway being created or updated is active.
  * Inactive pathways can now be created or updated without triggering unnecessary subtype overlap warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->